### PR TITLE
'top_level' decorator

### DIFF
--- a/oups/__init__.py
+++ b/oups/__init__.py
@@ -4,4 +4,4 @@
 Created on Wed Dec  1 18:35:00 2021
 @author: yoh
 """
-from .indexer import top_level
+from .indexer import sublevel, toplevel

--- a/oups/__init__.py
+++ b/oups/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec  1 18:35:00 2021
+@author: yoh
+"""
+from .indexer import top_level

--- a/oups/defines.py
+++ b/oups/defines.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec  1 18:35:00 2021
+@author: yoh
+"""
+
+
+DIR_SEP = '/'
+

--- a/oups/indexer.py
+++ b/oups/indexer.py
@@ -8,9 +8,11 @@ from dataclasses import dataclass, is_dataclass, fields
 from functools import partial
 from typing import Any, Iterator, List
 
+from oups.defines import DIR_SEP
 
-TYPE_ACCEPTED = {int, float, str}
-DIR_SEP = '/'
+
+# Float removed to prevent having '.' in field values.
+TYPE_ACCEPTED = {int, str}
 
 def _is_dataclass_instance(obj):
     return is_dataclass(obj) and not isinstance(obj, type)
@@ -51,23 +53,32 @@ def _validate_top_level(top_level):
     Parameters
     top_level : top_level dataclass
     """
+    forbidden_chars = (DIR_SEP, top_level._fields_sep)
     for fields_ in _dataclass_instance_to_lists(top_level):
         number_of_fields = len(fields_)
         for counter, field in enumerate(fields_):
             if _is_dataclass_instance(field):
                 if not counter:
-                    # A dataclass instance cannot be only field.
+                    # A dataclass instance cannot be the only field.
+                    # Detecting if it is in last position suffice, except if
+                    # there is only one field, in which case it is also in
+                    # 1st position.
                     raise TypeError('A dataclass instance cannot be the only \
 field of a level.')
                 if counter+1 != number_of_fields:
-                    # A dataclass instance is identified not in last position.
+                    # A dataclass instance cannot be in last position.
                     raise TypeError('A dataclass instance is only possible in \
 last position.')
             if not ((type(field) in TYPE_ACCEPTED)
                     or _is_dataclass_instance(field)):
                 raise TypeError(f'Field type {type(field)} not possible.')
+            field_as_str = str(field)
+            if any([symb in field_as_str for symb in forbidden_chars]):
+                raise ValueError(f'Use of a forbidden character among \
+{forbidden_chars} is not possible in field {field_as_str}.')
+    return
 
-def _dataclass_instance_to_str(top_level, as_path:bool=False):
+def _dataclass_instance_to_str(top_level, as_path:bool=False) -> str:
     levels_sep = DIR_SEP if as_path else top_level._fields_sep
     to_str = []
     for fields_ in _dataclass_instance_to_lists(top_level):
@@ -76,8 +87,44 @@ def _dataclass_instance_to_str(top_level, as_path:bool=False):
     to_str[-1] += f'{top_level._fields_sep}{str(fields_[-1])}'
     return levels_sep.join(to_str)
 
-# Not using '.' for 'fields_sep' as '.' can also be found in floats. It will
-# not be possible then to re-create from a string the indexer class. 
+def _dataclass_fields_types_to_lists(cls) -> List[List[Any]]:
+    """
+    Return the type of each field, one list per level, and all levels in a
+    list.
+
+    Parameters
+    cls : dataclass
+        A dataclass instance or a dataclass.
+
+    Returns
+    List[List[Any]]
+        List of fields types lists, one list per level.
+    """
+    types = [[field.type for field in fields(cls)]]
+    while is_dataclass(last := types[-1][-1]):
+        types.append([field.type for field in fields(last)])
+    return types
+
+def _dataclass_instance_from_str(cls, string:str, level_sep:str):
+    types = _dataclass_fields_types_to_lists(cls)
+    # Split string depending 'level_sep', into different levels.
+    string_as_list = string.split(level_sep)
+    # Manages last level first.
+    level_types = types.pop() # remove last element
+    level_length = len(level_types)
+    level = list(map(level_types, string_as_list[-level_length:]))
+    while types:
+        string_as_list = string_as_list[:level_length]
+        level_types = types.pop() # remove last element
+        level_length = len(level_types)-1
+        # Relying on the fact that a dataclass is necessarily the last field.
+        level = list(map(level_types[:-1],
+                              string_as_list[-level_length:])) \
+                     + level_types[-1](*level)
+    return level
+
+# Not using '.' for 'fields_sep' as '.' can also be found in floats.
+# It is not accepted by vaex. 
 def top_level(index_class=None, *, fields_sep:str='-'):
     def tweak(index_class):
         # Wrap with `@dataclass`.
@@ -87,16 +134,25 @@ def top_level(index_class=None, *, fields_sep:str='-'):
         # Copy of original __init__ to call it without recursion.
         index_class_init = index_class.__init__
         def __init__(self, *args, **kws):
-            object.__setattr__(self, "_fields_sep", fields_sep)
+#            object.__setattr__(self, "_fields_sep", fields_sep)
             index_class_init(self, *args, **kws)
             # Validate dataclass instance.
             _validate_top_level(self)
-    
+        # Set modified __init__, new methods, and new attributes.
         index_class.__init__ = __init__
+        # Need to define '_fields_sep' as class attribute, as used in
+        # 'from_path' and 'from_str'.
+        index_class._fields_sep = fields_sep
         index_class.__str__ = _dataclass_instance_to_str
         _dataclass_instance_to_str_p = partial(_dataclass_instance_to_str,
                                                as_path=True)
         index_class.to_path = property(_dataclass_instance_to_str_p)
+        _dataclass_instance_from_path = partial(_dataclass_instance_from_str,
+                                                level_sep=DIR_SEP)
+        index_class.from_path = classmethod(_dataclass_instance_from_path)
+        _dataclass_instance_from_str_p = partial(_dataclass_instance_from_str,
+                                                 level_sep=fields_sep)
+        index_class.from_path = classmethod(_dataclass_instance_from_str_p)
         return index_class
 
     if index_class:

--- a/oups/indexer.py
+++ b/oups/indexer.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec  1 18:35:00 2021
+@author: yoh
+"""
+from dataclasses import dataclass, is_dataclass, fields
+from functools import partial
+from typing import Any, Iterator, List
+
+
+TYPE_ACCEPTED = {int, float, str}
+DIR_SEP = '/'
+
+def _is_dataclass_instance(obj):
+    return is_dataclass(obj) and not isinstance(obj, type)
+
+def _dataclass_to_dict(obj):
+    # Shallow copy, not possible to use 'asdict()'.
+    return {field.name: getattr(obj, field.name) for field in fields(obj)}
+
+def _dataclass_instance_to_lists(obj) -> Iterator[List[Any]]:
+    """
+    Generator.
+    Return items as lists of fields values.
+    For each dataclass instance found, its fields values are returned again as
+    a list in a next item, and so on...
+
+    Parameters
+    obj : dataclass
+        May contain nested dataclass objects.
+    Returns
+    Iterator[List[Any]]
+        Yields list of fields values.
+    """
+    fields = list(_dataclass_to_dict(obj).values())
+    if fields:
+        yield fields
+        for field in fields:
+            if _is_dataclass_instance(field):
+                yield from _dataclass_instance_to_lists(field)
+
+def _validate_top_level(top_level):
+    """
+    Validate a 'top_level'-decorated data class instance.
+     - check only 'int', 'str', 'float' or another dataclass instance are used;
+     - check that there is at most only one dataclass instance per nesting
+       level, and if present, it is not the 1st field, nor the last field.
+     Raise a TypeError if instance is not compliant.
+
+    Parameters
+    top_level : top_level dataclass
+    """
+    for fields_ in _dataclass_instance_to_lists(top_level):
+        number_of_fields = len(fields_)
+        for counter, field in enumerate(fields_):
+            if _is_dataclass_instance(field):
+                if not counter:
+                    # A dataclass instance cannot be only field.
+                    raise TypeError('A dataclass instance cannot be the only \
+field of a level.')
+                if counter+1 != number_of_fields:
+                    # A dataclass instance is identified not in last position.
+                    raise TypeError('A dataclass instance is only possible in \
+last position.')
+            if not ((type(field) in TYPE_ACCEPTED)
+                    or _is_dataclass_instance(field)):
+                raise TypeError(f'Field type {type(field)} not possible.')
+
+def _dataclass_instance_to_str(top_level, as_path:bool=False):
+    levels_sep = DIR_SEP if as_path else top_level._fields_sep
+    to_str = []
+    for fields_ in _dataclass_instance_to_lists(top_level):
+        # Relying on the fact that only the tail can be a dataclass instance.
+        to_str.append(top_level._fields_sep.join(map(str,fields_[:-1])))
+    to_str[-1] += f'{top_level._fields_sep}{str(fields_[-1])}'
+    return levels_sep.join(to_str)
+
+# Not using '.' for 'fields_sep' as '.' can also be found in floats. It will
+# not be possible then to re-create from a string the indexer class. 
+def top_level(index_class=None, *, fields_sep:str='-'):
+    def tweak(index_class):
+        # Wrap with `@dataclass`.
+        # TODO
+        # When python 3.10 is more wide spread, set 'slot=True' to save RAM.
+        index_class = dataclass(index_class, order= True, frozen=True)
+        # Copy of original __init__ to call it without recursion.
+        index_class_init = index_class.__init__
+        def __init__(self, *args, **kws):
+            object.__setattr__(self, "_fields_sep", fields_sep)
+            index_class_init(self, *args, **kws)
+            # Validate dataclass instance.
+            _validate_top_level(self)
+    
+        index_class.__init__ = __init__
+        index_class.__str__ = _dataclass_instance_to_str
+        _dataclass_instance_to_str_p = partial(_dataclass_instance_to_str,
+                                               as_path=True)
+        index_class.to_path = property(_dataclass_instance_to_str_p)
+        return index_class
+
+    if index_class:
+        # Calling decorator without other parameters.
+        return tweak(index_class)
+    # Calling decorator with other parameters.
+    return tweak

--- a/oups/indexer.py
+++ b/oups/indexer.py
@@ -6,6 +6,7 @@ Created on Wed Dec  1 18:35:00 2021
 """
 from dataclasses import dataclass, is_dataclass, fields
 from functools import partial
+import re
 from typing import Any, Iterator, List
 
 from oups.defines import DIR_SEP
@@ -13,6 +14,9 @@ from oups.defines import DIR_SEP
 
 # Float removed to prevent having '.' in field values.
 TYPE_ACCEPTED = {int, str}
+# Characters forbidden in field value.
+# 'fields_sep' is also included before check.
+FORBIDDEN_CHARS = (DIR_SEP, '.')
 
 def _is_dataclass_instance(obj):
     return is_dataclass(obj) and not isinstance(obj, type)
@@ -42,10 +46,11 @@ def _dataclass_instance_to_lists(obj) -> Iterator[List[Any]]:
             if _is_dataclass_instance(field):
                 yield from _dataclass_instance_to_lists(field)
 
-def _validate_top_level(top_level):
+def _validate_top_level_obj(top_level):
     """
     Validate a 'top_level'-decorated data class instance.
-     - check only 'int', 'str', 'float' or another dataclass instance are used;
+     - check field type is only among 'int', 'str' or another dataclass
+       instance;
      - check that there is at most only one dataclass instance per nesting
        level, and if present, it is not the 1st field, nor the last field.
      Raise a TypeError if instance is not compliant.
@@ -53,11 +58,12 @@ def _validate_top_level(top_level):
     Parameters
     top_level : top_level dataclass
     """
-    forbidden_chars = (DIR_SEP, top_level._fields_sep)
+    forbidden_chars = (top_level._fields_sep, *FORBIDDEN_CHARS)
     for fields_ in _dataclass_instance_to_lists(top_level):
         number_of_fields = len(fields_)
         for counter, field in enumerate(fields_):
             if _is_dataclass_instance(field):
+                # If a dataclass instance.
                 if not counter:
                     # A dataclass instance cannot be the only field.
                     # Detecting if it is in last position suffice, except if
@@ -69,13 +75,15 @@ field of a level.')
                     # A dataclass instance cannot be in last position.
                     raise TypeError('A dataclass instance is only possible in \
 last position.')
+            else:
+                # If not a dataclass instance.
+                field_as_str = str(field)
+                if any([symb in field_as_str for symb in forbidden_chars]):
+                    raise ValueError(f'Use of a forbidden character among \
+{forbidden_chars} is not possible in {field_as_str}.')
             if not ((type(field) in TYPE_ACCEPTED)
                     or _is_dataclass_instance(field)):
                 raise TypeError(f'Field type {type(field)} not possible.')
-            field_as_str = str(field)
-            if any([symb in field_as_str for symb in forbidden_chars]):
-                raise ValueError(f'Use of a forbidden character among \
-{forbidden_chars} is not possible in field {field_as_str}.')
     return
 
 def _dataclass_instance_to_str(top_level, as_path:bool=False) -> str:
@@ -105,27 +113,52 @@ def _dataclass_fields_types_to_lists(cls) -> List[List[Any]]:
         types.append([field.type for field in fields(last)])
     return types
 
-def _dataclass_instance_from_str(cls, string:str, level_sep:str):
+def _dataclass_instance_from_str(cls, string:str, fields_sep:str):
     types = _dataclass_fields_types_to_lists(cls)
-    # Split string depending 'level_sep', into different levels.
-    string_as_list = string.split(level_sep)
+    # Split string depending 'fields_sep' and 'DIR_SEP', into different fields.
+    strings_as_list = re.split(fr'{DIR_SEP}|\{fields_sep}', string)
     # Manages last level first.
     level_types = types.pop() # remove last element
     level_length = len(level_types)
-    level = list(map(level_types, string_as_list[-level_length:]))
+    level = [field_type(field_as_string) for field_type, field_as_string
+             in zip(level_types, strings_as_list[-level_length:])]
     while types:
-        string_as_list = string_as_list[:level_length]
+        strings_as_list = strings_as_list[:-level_length]
         level_types = types.pop() # remove last element
         level_length = len(level_types)-1
         # Relying on the fact that a dataclass is necessarily the last field.
-        level = list(map(level_types[:-1],
-                              string_as_list[-level_length:])) \
-                     + level_types[-1](*level)
-    return level
+        level = [field_type(field_as_string) for field_type, field_as_string
+                 in zip(level_types[:-1], strings_as_list[-level_length:])]\
+                + [level_types[-1](*level)]
+    return cls(*level)
 
-# Not using '.' for 'fields_sep' as '.' can also be found in floats.
-# It is not accepted by vaex. 
-def top_level(index_class=None, *, fields_sep:str='-'):
+def toplevel(index_class=None, *, fields_sep:str='-'):
+    """
+    Decorate a class into a dataclass with methods and attributes to use it
+    as a dataset index.
+    Decorated class has to be defined as one would define a class decorated by
+    '@dataclass'.
+    '@dataclass' is actually called when decorating with '@toplevel' with
+    parameters set to:
+        - order=True,
+        - frozen=True
+    
+    'top_level' is to be used as a decorator, with or without parameter
+    'fields_sep'.
+
+    Class instanciation is checked.
+      - An instance can only be composed with `int`, 'str' or a dataclass
+        object coming in last position;
+      - Value of attribute can not incorporate forbidden characters like '/'
+        and 'self._fields_sep'.
+
+    Parameters
+    fields_sep : str, default '.'
+        Character to use as separator between fields of the dataclass.
+
+    Returns
+    Decorated class.
+    """
     def tweak(index_class):
         # Wrap with `@dataclass`.
         # TODO
@@ -137,7 +170,7 @@ def top_level(index_class=None, *, fields_sep:str='-'):
 #            object.__setattr__(self, "_fields_sep", fields_sep)
             index_class_init(self, *args, **kws)
             # Validate dataclass instance.
-            _validate_top_level(self)
+            _validate_top_level_obj(self)
         # Set modified __init__, new methods, and new attributes.
         index_class.__init__ = __init__
         # Need to define '_fields_sep' as class attribute, as used in
@@ -148,11 +181,9 @@ def top_level(index_class=None, *, fields_sep:str='-'):
                                                as_path=True)
         index_class.to_path = property(_dataclass_instance_to_str_p)
         _dataclass_instance_from_path = partial(_dataclass_instance_from_str,
-                                                level_sep=DIR_SEP)
+                                                fields_sep=fields_sep)
         index_class.from_path = classmethod(_dataclass_instance_from_path)
-        _dataclass_instance_from_str_p = partial(_dataclass_instance_from_str,
-                                                 level_sep=fields_sep)
-        index_class.from_path = classmethod(_dataclass_instance_from_str_p)
+        index_class.from_str = classmethod(_dataclass_instance_from_path)
         return index_class
 
     if index_class:
@@ -160,3 +191,15 @@ def top_level(index_class=None, *, fields_sep:str='-'):
         return tweak(index_class)
     # Calling decorator with other parameters.
     return tweak
+
+def sublevel(index_class):
+    """
+    Decorator to be used as an alias of '@dataclass' decorator, with parameters
+    set to:
+        - order=True,
+        - frozen=True
+    """ 
+    # Wrap with `@dataclass`.
+    # TODO
+    # When python 3.10 is more wide spread, set 'slot=True' to save RAM.
+    return dataclass(index_class, order= True, frozen=True)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec  1 18:35:00 2021
+@author: yoh
+"""
+from setuptools import setup
+
+
+setup(
+    name="oups",
+    version="0.1",
+    author="Yoh Plala",
+    author_email="yoh.plala@gmail.com",
+    url="https://github.com/yohplala/oups",
+    description="Ordered Updatable Parquet Store",
+    python_requires=">=3.8",
+    tests_require=["pytest"],
+    install_requires=["pandas>=1.3.1",
+                      "fastparquet>=0.7.1"]
+)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec  1 18:35:00 2021
+@author: yoh
+"""
+from dataclasses import dataclass
+import pytest
+
+from oups import top_level
+from oups.indexer import DIR_SEP
+
+
+def test_top_level_to_str():
+    # Test without parameter.
+    @top_level
+    class Test:
+        mu : int
+        nu : str
+    test = Test(3, 'oh')
+    assert str(test) == '3-oh'
+    
+    # Test with 'fields_sep' parameter.
+    @top_level(fields_sep='.')
+    class Test:
+        mu : int
+        nu : str
+    test = Test(3, 'oh')
+    assert str(test) == '3.oh'
+
+def test_top_level_equality_and_dict():    
+    # Test (un)equality.
+    @top_level
+    class Test:
+        mu : int
+        nu : str
+    test1 = Test(3, 'oh')
+    test2 = Test(3, 'oh')
+    assert test1 == test2
+    test3 = Test(4, 'oh')
+    assert test1 != test3
+    
+    # Test dict.
+    di = {test1:[1,2,3], test2:[7,8,9]}
+    assert len(di) == 1
+    assert di[Test(3, 'oh')] == [7,8,9]
+
+def test_top_level_nested_dataclass():
+    # Test 'normal' use case.
+    # (only int, float, str or dataclass instance in last position)
+    @dataclass(order=True, frozen=True)
+    class SubLevel2:
+        ma: str
+        to: int
+        ou: float    
+
+    @dataclass(order=True, frozen=True)
+    class SubLevel1:
+        pu: float
+        il: str
+        iv: SubLevel2
+
+    @top_level
+    class TopLevel:
+        ma: str
+        to: int
+        fo: SubLevel1
+
+    sl2 = SubLevel2('ou', 3, 7.2)
+    sl1 = SubLevel1(5.6, 'oh', sl2)
+    # Should not raise an exception.
+    tl = TopLevel('aha', 2, sl1)
+    to_str_ref = 'aha-2-5.6-oh-ou-3-7.2'
+    assert str(tl) == to_str_ref
+    to_str_ref = DIR_SEP.join(['aha-2','5.6-oh','ou-3-7.2'])
+    assert tl.to_path == to_str_ref
+
+    # Test validation with wrong data type.
+    @dataclass(order=True, frozen=True)
+    class SubLevel1:
+        pu: float
+        il: dict
+        iv: SubLevel2
+
+    sl1 = SubLevel1(5.6, {5:['ah']}, sl2)
+    with pytest.raises(TypeError, match='^Field type'):
+        tl = TopLevel('aha', 2, sl1)
+
+    # Test validation with several dataclass instance at same level.
+    @dataclass(order=True, frozen=True)
+    class SubLevel1:
+        pu: float
+        il: str
+        iv: SubLevel2
+        po: SubLevel2
+
+    sl2_ = SubLevel2('fi', 9, 2.8)
+    sl1 = SubLevel1(5.6, 'oh', sl2, sl2_)
+    with pytest.raises(TypeError, match='^A dataclass instance is only'):
+        tl = TopLevel('aha', 2, sl1)
+
+    # Test validation with a single dataclass instance in a level.
+    @dataclass(order=True, frozen=True)
+    class SubLevel1:
+        iv: SubLevel2
+
+    sl1 = SubLevel1(sl2)
+    with pytest.raises(TypeError, match='^A dataclass instance cannot be'):
+        tl = TopLevel('aha', 2, sl1)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -52,11 +52,11 @@ def test_top_level_nested_dataclass():
     class SubLevel2:
         ma: str
         to: int
-        ou: float    
+        ou: int  
 
     @dataclass(order=True, frozen=True)
     class SubLevel1:
-        pu: float
+        pu: int
         il: str
         iv: SubLevel2
 
@@ -66,13 +66,13 @@ def test_top_level_nested_dataclass():
         to: int
         fo: SubLevel1
 
-    sl2 = SubLevel2('ou', 3, 7.2)
-    sl1 = SubLevel1(5.6, 'oh', sl2)
+    sl2 = SubLevel2('ou', 3, 7)
+    sl1 = SubLevel1(5, 'oh', sl2)
     # Should not raise an exception.
     tl = TopLevel('aha', 2, sl1)
-    to_str_ref = 'aha-2-5.6-oh-ou-3-7.2'
+    to_str_ref = 'aha-2-5-oh-ou-3-7'
     assert str(tl) == to_str_ref
-    to_str_ref = DIR_SEP.join(['aha-2','5.6-oh','ou-3-7.2'])
+    to_str_ref = DIR_SEP.join(['aha-2','5-oh','ou-3-7'])
     assert tl.to_path == to_str_ref
 
     # Test validation with wrong data type.
@@ -107,3 +107,10 @@ def test_top_level_nested_dataclass():
     sl1 = SubLevel1(sl2)
     with pytest.raises(TypeError, match='^A dataclass instance cannot be'):
         tl = TopLevel('aha', 2, sl1)
+
+
+# /!\ Test error if use of a forbidden character! (a float as a string for instance)
+
+# from_path: tester avec un niveau avec seulement une valeur & une dataclass
+
+


### PR DESCRIPTION
Decorator to be to be used on user-defined data class.
This data class objects define keys/index to retrieve parquet dataset (a folder strucutre).

Objective of this work is to _simplify_ as much as possible creation of data class suited for this purpose.
_top_level_ equips the top level data class with functions and attributes:
- [x] `fields_sep`
- [x] `__str__`
- [x] `to_path`
- [x] `from_path`

Also:
- [x] nested dataclass to define different folder levels is also supported
- [x] 'lose' validation at instanciation for types and position of nested data class if any
- [x] test cases
- [ ] documentation