### PR TITLE
Streamagg2

### DIFF
--- a/oups/collection.py
+++ b/oups/collection.py
@@ -169,10 +169,10 @@ class ParquetSet:
         """
         if not isinstance(key, self._indexer):
             raise TypeError(f"{key} is not an instance of {self._indexer.__name__}.")
-        if not isinstance(data, pDataFrame) and not isinstance(data, vDataFrame):
+        if not isinstance(data, (pDataFrame, vDataFrame)):
             raise TypeError("data should be a pandas or vaex dataframe.")
         dirpath = os_path.join(self._basepath, key.to_path)
-        write(dirpath=dirpath, data=data, **kwargs)
+        write(dirpath=dirpath, data=data, md_key=key, **kwargs)
         # If no trouble from writing, add key.
         self._keys.add(key)
         return

--- a/oups/streamagg.py
+++ b/oups/streamagg.py
@@ -1414,6 +1414,8 @@ def streamagg(
             print("seed_chunk after concat and rename")
             print(seed_chunk)
             print("")
+            print("reduction_agg")
+            print(reduction_agg)
             seed_chunk = seed_chunk.groupby(reduction_bin_cols, sort=False).agg(**reduction_agg)
             seed_chunk.reset_index(inplace=True)
             print("seed_chunk after groupby")

--- a/oups/streamagg.py
+++ b/oups/streamagg.py
@@ -1324,9 +1324,7 @@ def streamagg(
     # Parameter setup.
     if not isinstance(key, dict):
         if not agg:
-            raise ValueError(
-                "not possible to use a single key without" " specifying parameter 'agg'."
-            )
+            raise ValueError("not possible to use a single key without specifying parameter 'agg'.")
         key = {key: {"agg": agg, "by": by, "bin_on": bin_on, "post": post}}
     (
         all_cols_in,

--- a/oups/streamagg.py
+++ b/oups/streamagg.py
@@ -4,6 +4,7 @@ Created on Wed Mar  9 21:30:00 2022.
 
 @author: yoh
 """
+from copy import copy
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Tuple, Union
 
@@ -249,6 +250,112 @@ def _post_n_write_agg_chunks(
     store[key] = write_config, agg_res
 
 
+def _setup_binning(
+    reduction: bool,
+    key_idx: int,
+    by: Union[Callable, Grouper, None] = None,
+    bin_on: Union[str, Tuple[str, str]] = None,
+):
+    """Specifically operate binning setup.
+
+    Parameters
+    ----------
+    reduction : bool
+        Flag indicating if reduction step will be performed on seed chunk or
+        not.
+    key_idx: int
+        Key position in 'keys' dict.
+    by : Callable, pd.Grouper or str, default None
+        Defines the binning logic.
+    bin_on : str, or Tuple[str, str], default None
+        Name of the column from which deriving bins.
+
+    Returns
+    -------
+    by, cols_to_by, bins
+
+          - ``by`` Callable, pandas Grouper, or str. It becomes a string if
+            set to ``None`` by the user and ``bin_on`` is defined. It is used
+            to define the bins either for the reduction step, or if not, the
+            bin array when is a Callable for the individual binning.
+          - ``cols_to_by`` str, column name required for ``by`` is ``by`` is a
+            Callable or pandas Grouper.
+          - ``generic_bin_col``, str, generic bin column name used between the
+            common reduction step and the individual groupby step for each key.
+          -  ``bins`` str or pandas Grouper. It is the parameter used to
+            achieve the individual binning for each key.
+          - ``bin_out_col`` str. Bin column is renamed to this value when
+            writing results. If no value is defined, and ``bin_on`` itself is
+            ``None``, then the default value it takes is `index` (set by
+            default by pandas when resetting an index without name).
+
+    """
+    print("")
+    print("_setup_binning")
+    print("reduction")
+    print(reduction)
+    generic_bin_col = f"key_{key_idx}" if reduction else None
+    if bin_on:
+        if isinstance(bin_on, tuple):
+            # 'bin_out_col' is name of column containing group keys in 'agg_res'.
+            bin_on, bin_out_col = bin_on
+        else:
+            bin_out_col = bin_on
+        # If 'bin_on' defined, it defines the column to be loaded for binning.
+        cols_to_by = bin_on
+    else:
+        cols_to_by = None
+        bin_out_col = None
+    if isinstance(by, Grouper):
+        # Case pandas Grouper.
+        # https://pandas.pydata.org/docs/reference/api/pandas.Grouper.html
+        by_key = by.key
+        if bin_on and by_key and bin_on != by_key:
+            raise ValueError(
+                "two different columns are defined for achieving binning,"
+                " both by `bin_on` and `by` parameters, pointing to"
+                f" '{bin_on}' and '{by_key}' columns respectively."
+            )
+        elif by_key and not bin_on:
+            bin_out_col = by_key
+        elif bin_on and not by_key:
+            by.key = bin_on
+        elif not (bin_on or by_key):
+            # Nor 'by.key', nor 'bin_on' defined.
+            raise ValueError(
+                "no column name defined to bin with provided pandas grouper" f" `{by}`."
+            )
+        # If 'by' a pandas Grouper, its 'key' attribute defines the column to
+        # be loaded for binning.
+        cols_to_by = by.key
+        if reduction:
+            # When 'by' is a Grouper, reduction or not reduction, 'bins' is
+            # same Grouper, except its key value.
+            bins = copy(by)
+            bins.key = generic_bin_col
+        else:
+            bins = by
+    elif callable(by):
+        # Case Callable.
+        # If no reduction, 'bins' is updated on the fly within the loop
+        # with bin label for each row.
+        # Otherwise 'bins' is column name that will get the bin labels.
+        bins = generic_bin_col if reduction else None
+    elif by is None and bin_on:
+        # Case 'bin_on' is a column name, and 'by' is undefined.
+        if reduction:
+            # 'bins' is column name that will get the bin labels.
+            by = bin_on
+            bins = generic_bin_col
+        else:
+            bins = bin_on
+    elif by:
+        raise TypeError(f"not possible to have 'by' of type {type(by)}.")
+    else:
+        raise ValueError("at least one among `by` and `bin_on` is required.")
+    return by, cols_to_by, generic_bin_col, bins, bin_out_col
+
+
 def _setup(
     store: ParquetSet,
     keys: Dict[dataclass, dict],
@@ -310,7 +417,7 @@ def _setup(
                      'agg_res' : None,
                      'agg_res_len' : None,
                      'isfbn' : True,
-                     'by' : pandas grouper or callable,
+                     'by' : pandas Grouper, Callable or str (column name),
                      'bins' : pandas grouper or str (column name),
                      'cols_to_by' : list or None,
                      'bin_out_col' : str,
@@ -340,98 +447,58 @@ def _setup(
     seed_index_restart_set = set()
     all_cols_in = {ordered_on}
     reduction_agg = {}
+    reduction_bin_cols = {}
     # Some default values for keys.
     # 'agg_n_rows' : number of rows in aggregation result.
     # 'isfbn': is first row (from aggregation result) a new bin?
     #          For 1st iteration it is necessarily a new one.
     # 'last_agg_row' : initialized to an empty pandas dataframe, to allow using
     #                  'empty' attribute in subsequent loop.
-    # Keys 'cols_to_by', 'by' and 'bins' are updated in below code if it makes
-    # sense with respect to other values of other parameters.
+    last_agg_row_dft = pDataFrame()
     key_default = {
-        "last_agg_row": pDataFrame(),
         "agg_n_rows": 0,
         "agg_mean_row_group_size": 0,
         "agg_res": None,
         "agg_res_len": None,
         "isfbn": True,
-        "cols_to_by": None,
         "by": None,
         "bins": None,
     }
-    for key, key_conf_in in keys.items():
+    for i, (key, key_conf_in) in enumerate(keys.items()):
         # Parameters in 'key_conf_in' take precedence over those in 'kwargs'.
         key_conf_in = kwargs | key_conf_in
-        # Initialize 'key_conf_out' with default values.
-        key_conf_out = key_default.copy()
         # Step 1 / Process parameters.
         # Step 1.1 / 'by' and 'bin_on'.
         # Initialize 'bins' and 'bin_out_col' from 'by' and 'bin_on'.
         bin_on = key_conf_in.pop("bin_on", None)
         by = key_conf_in.pop("by", None)
+        (by, cols_to_by, generic_bin_col, bins, bin_out_col) = _setup_binning(
+            reduction=reduction, key_idx=i, by=by, bin_on=bin_on
+        )
+        # 'cols_to_by' defines columns to be loaded and sent to 'by' when 'by'
+        # is a Callable of pandas Grouper. It has to be completed with
+        # 'ordered_on'.
+        if cols_to_by:
+            # Make sure it is in the columns to be loaded in seed.
+            all_cols_in.add(cols_to_by)
+            cols_to_by = [ordered_on, cols_to_by]
+        else:
+            cols_to_by = ordered_on
         # 'agg' required right at this step.
         # Making a copy as 'agg' may possibly be a dict coming from default
         # config. Because it get modified in below code, it is necessary to
         # modify the copy, and not the reference.
-        agg = key_conf_in.pop("agg").copy()
-        if bin_on:
-            if isinstance(bin_on, tuple):
-                # 'bin_out_col' is name of column containing group keys in 'agg_res'.
-                bin_on, bin_out_col = bin_on
-            else:
-                bin_out_col = bin_on
-        else:
-            bin_out_col = None
-        if by:
-            if callable(by):
-                if bin_on == ordered_on or not bin_on:
-                    # Define columns forwarded to 'by'.
-                    key_conf_out["cols_to_by"] = [ordered_on]
-                else:
-                    key_conf_out["cols_to_by"] = [ordered_on, bin_on]
-            elif isinstance(by, Grouper):
-                # Case pandas grouper.
-                # https://pandas.pydata.org/docs/reference/api/pandas.Grouper.html
-                by_key = by.key
-                if bin_on and by_key and bin_on != by_key:
-                    raise ValueError(
-                        "two different columns are defined for "
-                        "achieving binning, both by `bin_on` and `by` "
-                        f"parameters, pointing to '{bin_on}' and "
-                        f"'{by_key}' columns respectively."
-                    )
-                elif by_key and not bin_on:
-                    bin_on = by_key
-                    bin_out_col = by_key
-                elif bin_on and not by_key:
-                    by.key = bin_on
-                elif not (bin_on or by_key):
-                    # Nor 'by.key', nor 'bin_on' defined.
-                    raise ValueError(
-                        "no column name defined to bin with provided pandas"
-                        f" grouper for key '{key}'."
-                    )
-                key_conf_out["bins"] = by
-            else:
-                raise TypeError(f"not possible to have 'by' of type {type(by)}.")
-            key_conf_out["by"] = by
-        elif bin_on:
-            # Case of using values of an existing column directly for binning.
-            key_conf_out["by"] = bin_on
-            key_conf_out["bins"] = bin_on
-        else:
-            raise ValueError("at least one among `by` and `bin_on` is required.")
-        if bin_on:
-            # Make sure it is in the columns to be loaded in seed.
-            all_cols_in.add(bin_on)
+        agg = key_conf_in.pop("agg")
         if bin_out_col in agg:
             # Check that this name is not already that of an output column
             # from aggregation.
             raise ValueError(
-                f"not possible to have {bin_on} as column name in aggregated "
-                "results as it is also for column containing group keys."
+                f"not possible to have {bin_out_col} as column name in"
+                " aggregated results as it is also for column containing group"
+                " keys."
             )
-        key_conf_out["bin_out_col"] = bin_out_col
+        if reduction:
+            reduction_bin_cols[key] = generic_bin_col
         # Step 1.2 / 'agg' and 'post'.
         # Initialize 'self_agg', 'agg' and update 'reduction_agg', 'all_cols_in'.
         self_agg = {}
@@ -444,29 +511,31 @@ def _setup(
                 raise ValueError(f"aggregation function '{agg_func}' is not tested yet.")
             # Update 'all_cols_in', list of columns from seed to be loaded.
             all_cols_in.add(col_in)
-            # Update 'reduction_agg', required for reduction step.
-            # 'reduction_agg' is in the form:
-            # {("input_col_name__agg_function_name") : ("input_col", "agg_function_name")}
-            generic_col_name = f"{col_in}__{agg_func}"
-            if generic_col_name not in reduction_agg:
-                reduction_agg[generic_col_name] = (col_in, agg_func)
-            # Modify consequently 'agg' so that it can operate on agg results from
-            # reduction step.
-            key_agg[col_out] = (generic_col_name, agg_func)
+            if reduction:
+                # Update 'reduction_agg', required for reduction step.
+                # 'reduction_agg' is in the form:
+                # {("input_col_name__agg_function_name") : ("input_col", "agg_function_name")}
+                generic_agg_col = f"{col_in}__{agg_func}"
+                if generic_agg_col not in reduction_agg:
+                    reduction_agg[generic_agg_col] = (col_in, agg_func)
+                # Modify consequently 'agg' so that it can operate on agg results from
+                # reduction step.
+                key_agg[col_out] = (generic_agg_col, agg_func)
+            else:
+                key_agg = agg
             # Update 'self_agg', required for stitching step.
             self_agg[col_out] = (col_out, agg_func)
-        key_conf_out["self_agg"] = self_agg
-        key_conf_out["agg"] = key_agg if reduction else agg
         # Initialize 'post'.
-        key_conf_out["post"] = key_conf_in.pop("post")
+        post = key_conf_in.pop("post")
         # Step 1.3 / 'max_agg_row_group' and 'write_config'.
         # Initialize aggregation result max size before writing to disk.
-        if "max_row_group_size" in key_conf_in:
-            # If present, keep 'max_row_group_size' within 'key_conf_in' as it
-            # is a parameter to be forwarded to the writer.
-            key_conf_out["max_agg_row_group_size"] = key_conf_in["max_row_group_size"]
-        else:
-            key_conf_out["max_agg_row_group_size"] = MAX_ROW_GROUP_SIZE
+        # If present, keep 'max_row_group_size' within 'key_conf_in' as it
+        # is a parameter to be forwarded to the writer.
+        max_agg_row_group_size = (
+            key_conf_in["max_row_group_size"]
+            if "max_row_group_size" in key_conf_in
+            else MAX_ROW_GROUP_SIZE
+        )
         # Initialize 'write_config', which are parameters remaining in
         # 'key_conf_in' and some adjustments.
         # Forcing 'ordered_on' for write.
@@ -475,47 +544,55 @@ def _setup(
         # already. In this case, if 'bin_out_col' is not in 'duplicates_on', it is
         # understood as a voluntary user choice to not have 'bin_on' in
         # 'duplicates_on'.
+        # For all other cases, 'duplicates_on' has been set by user.
+        # If 'bin_out_col' is not in 'duplicates_on', it is understood as a
+        # voluntary choice by the user.
         if "duplicates_on" not in key_conf_in or key_conf_in["duplicates_on"] is None:
             if bin_out_col:
                 # Force 'bin_out_col'.
                 key_conf_in["duplicates_on"] = bin_out_col
             else:
                 key_conf_in["duplicates_on"] = ordered_on
-            # For all other cases, 'duplicates_on' has been set by user.
-            # If 'bin_out_col' is not in 'duplicates_on', it is understood as a
-            # voluntary choice by the user.
-        key_conf_out["write_config"] = key_conf_in
         # Step 2 / Process metadata if already existing aggregation results.
         # Initialize variables.
-        binning_buffer = {}
-        post_buffer = {}
         if key in store:
+            # Prior streamagg results already in store.
+            # Retrieve corresponding metadata to re-start aggregations.
             prev_agg_res = store[key]
-            if _is_stremagg_result(prev_agg_res):
-                # Prior streamagg results already in store.
-                # Retrieve corresponding metadata to re-start aggregations.
-                seed_index_restart, last_agg_row, binning_buffer, post_buffer = _get_streamagg_md(
-                    prev_agg_res
-                )
-                seed_index_restart_set.add(seed_index_restart)
-                key_conf_out["last_agg_row"] = last_agg_row
-                key_conf_out["binning_buffer"] = binning_buffer
-                key_conf_out["post_buffer"] = post_buffer
-            else:
+            if not _is_stremagg_result(prev_agg_res):
                 raise ValueError(f"provided key '{key}' is not that of 'streamagg' results.")
+            seed_index_restart, last_agg_row, binning_buffer, post_buffer = _get_streamagg_md(
+                prev_agg_res
+            )
+            seed_index_restart_set.add(seed_index_restart)
         else:
-            # Results not existing yet. Whatever 'trim_start' value, no trimming
-            # is possible yet.
-            trim_start = False
+            last_agg_row = last_agg_row_dft
             # Because 'binning_buffer' and 'post_buffer' are modified in-place
             # for each key, they are created separately for each key.
-            key_conf_out["binning_buffer"] = {}
-            key_conf_out["post_buffer"] = {}
-        # Initialize 'agg_chunks_buffer', buffer to keep aggregation chunks
+            binning_buffer = {}
+            post_buffer = {}
+        # 'agg_chunks_buffer' is a buffer to keep aggregation chunks
         # before a concatenation to record. Because it is appended in-place
         # for each key, it is created separately for each key.
-        key_conf_out["agg_chunks_buffer"] = []
-        keys_config[key] = key_conf_out
+        keys_config[key] = key_default | {
+            "post": post,
+            "self_agg": self_agg,
+            "agg": key_agg,
+            "bin_out_col": bin_out_col,
+            "cols_to_by": cols_to_by,
+            "by": by,
+            "bins": bins,
+            "max_agg_row_group_size": max_agg_row_group_size,
+            "agg_chunks_buffer": [],
+            "last_agg_row": last_agg_row,
+            "binning_buffer": binning_buffer,
+            "post_buffer": post_buffer,
+            "write_config": key_conf_in,
+        }
+    if not seed_index_restart_set:
+        # No aggrgation result existing yet. Whatever 'trim_start' value, no
+        # trimming is possible.
+        trim_start = False
     return (list(all_cols_in), trim_start, seed_index_restart_set, reduction_agg, keys_config)
 
 
@@ -1090,6 +1167,10 @@ def streamagg(
           voluntary choice from the user.
 
     """
+    print("")
+    print("streamagg")
+    print("reduction")
+    print(reduction)
     # Parameter setup.
     if not isinstance(key, dict):
         if not agg:

--- a/oups/streamagg.py
+++ b/oups/streamagg.py
@@ -1360,9 +1360,10 @@ def streamagg(
         seed, ordered_on, trim_start, seed_index_restart, discard_last, all_cols_in
     )
     for seed_chunk in iter_data:
+        print("")
         print("start of loop")
-        #        print("seed_chunk")
-        #        print(seed_chunk)
+        print("seed_chunk")
+        print(seed_chunk)
         # To be parallelized "_post_n_bin".
         # For using joblib here, check (+ memap for seed_chunk binning)
         # https://stackoverflow.com/questions/61215938/joblib-parallelization-of-function-with-multiple-keyword-arguments

--- a/oups/streamagg.py
+++ b/oups/streamagg.py
@@ -116,6 +116,7 @@ def _get_streamagg_md(handle: ParquetHandle) -> tuple:
 
 
 def _set_streamagg_md(
+    key: dataclass,
     last_seed_index=None,
     binning_buffer: dict = None,
     last_agg_row: pDataFrame = None,
@@ -125,6 +126,8 @@ def _set_streamagg_md(
 
     Parameters
     ----------
+    key : dataclass
+        Key of data in oups stor for which metadata is to be written.
     last_seed_index : default None
         Last index in seed data. Can be numeric type, timestamp...
     binning_buffer : dict
@@ -158,7 +161,7 @@ def _set_streamagg_md(
             MD_KEY_POST_BUFFER: post_buffer,
         }
     }
-    OUPS_METADATA.update(metadata)
+    OUPS_METADATA[key] = metadata
 
 
 def _post_n_write_agg_chunks(
@@ -243,7 +246,7 @@ def _post_n_write_agg_chunks(
         agg_res = post(agg_res, isfbn, post_buffer)
     if other_metadata:
         # Set oups metadata.
-        _set_streamagg_md(*other_metadata, post_buffer)
+        _set_streamagg_md(key, *other_metadata, post_buffer)
     # Record data.
     store[key] = write_config, agg_res
 
@@ -1115,8 +1118,8 @@ def streamagg(
         #        print("main loop")
         #        print("bins")
         #        print(bins)
-        for key, conf in bins_n_conf:
-            keys_config[key].update(conf)
+        for key, config in bins_n_conf:
+            keys_config[key].update(config)
         #        print("keys_config")
         #        print(keys_config)
 
@@ -1145,8 +1148,8 @@ def streamagg(
             _group_n_stitch(seed_chunk=seed_chunk, key=key, **config)
             for key, config in keys_config.items()
         ]
-        for key, conf in agg_res_n_conf:
-            keys_config[key].update(conf)
+        for key, config in agg_res_n_conf:
+            keys_config[key].update(config)
         # WiP here to keep group of workers for next step (post and bin or last post).
 
     # /!\ WiP /!\ here use result from reduction step to check if something done.

--- a/oups/streamagg.py
+++ b/oups/streamagg.py
@@ -290,10 +290,6 @@ def _setup_binning(
             default by pandas when resetting an index without name).
 
     """
-    print("")
-    print("_setup_binning")
-    print("reduction")
-    print(reduction)
     generic_bin_col = f"key_{key_idx}" if reduction else None
     if bin_on:
         if isinstance(bin_on, tuple):
@@ -418,21 +414,21 @@ def _setup(
                      'agg_res_len' : None,
                      'isfbn' : True,
                      'by' : pandas Grouper, Callable or str (column name),
-                     'bins' : pandas grouper or str (column name),
                      'cols_to_by' : list or None,
-                     'bin_out_col' : str,
-                     'self_agg' : dict,
+                     'bins' : pandas grouper or str (column name),
                      'agg' : dict,
+                     'self_agg' : dict,
+                     'bin_out_col' : str,
                      'post' : Callable or None,
                      'max_agg_row_group_size' : int,
+                     'agg_chunk_buffer' : agg_chunk_buffer,
+                     'last_agg_row' : empty pandas dataframe,
+                     'binning_buffer' : dict, possibly empty,
+                     'post_buffer' : dict, possibly empty,
                      'write_config' : {'ordered_on' : str,
                                        'duplicates_on' : str or list,
                                        ...
                                        },
-                     'binning_buffer' : dict, possibly empty,
-                     'last_agg_row' : empty pandas dataframe,
-                     'post_buffer' : dict, possibly empty,
-                     'agg_chunk_buffer' : agg_chunk_buffer,
                      },
                }``
             To be noticed:
@@ -521,10 +517,10 @@ def _setup(
                 # Modify consequently 'agg' so that it can operate on agg results from
                 # reduction step.
                 key_agg[col_out] = (generic_agg_col, agg_func)
-            else:
-                key_agg = agg
             # Update 'self_agg', required for stitching step.
             self_agg[col_out] = (col_out, agg_func)
+        if not reduction:
+            key_agg = agg
         # Initialize 'post'.
         post = key_conf_in.pop("post")
         # Step 1.3 / 'max_agg_row_group' and 'write_config'.
@@ -575,13 +571,13 @@ def _setup(
         # before a concatenation to record. Because it is appended in-place
         # for each key, it is created separately for each key.
         keys_config[key] = key_default | {
-            "post": post,
-            "self_agg": self_agg,
-            "agg": key_agg,
-            "bin_out_col": bin_out_col,
-            "cols_to_by": cols_to_by,
             "by": by,
+            "cols_to_by": cols_to_by,
             "bins": bins,
+            "agg": key_agg,
+            "self_agg": self_agg,
+            "bin_out_col": bin_out_col,
+            "post": post,
             "max_agg_row_group_size": max_agg_row_group_size,
             "agg_chunks_buffer": [],
             "last_agg_row": last_agg_row,

--- a/oups/utils.py
+++ b/oups/utils.py
@@ -7,6 +7,12 @@ Created on Wed Dec  4 21:30:00 2021.
 from os import scandir
 from typing import Iterator, List, Tuple
 
+from pandas import Grouper
+from pandas import Series
+from pandas import cut
+from pandas import date_range
+from pandas.core.resample import _get_timestamp_range_edges as gtre
+
 from oups.defines import DIR_SEP
 
 
@@ -68,3 +74,57 @@ def strip_path_tail(dirpath: str) -> str:
     """
     if DIR_SEP in dirpath:
         return dirpath.rsplit("/", 1)[0]
+
+
+def tcut(data: Series, grouper: Grouper):
+    """Perform binning with provided grouper.
+
+    Achieve binning of data by dates as specified by provided pandas grouper.
+    Rows falling in same period will get same label.
+    On the opposite to labels that would be returned by a pandas `groupby`
+    using provided grouper, labels returned by `dcut` systematically fall in
+    the bin they belong to.
+
+    Parameters
+    ----------
+    data : pandas.Series
+        Series or array-like which values will be binned.
+    grouper : pandas.Grouper
+        Specifications according which defining the time bins.
+
+    Returns
+    -------
+    pandas.Series
+        Series with same length as initial array, with values as categories,
+        which name fall into bins specified by the grouper.
+
+    Notes
+    -----
+    - When performing a `groupby` with a grouper having attributes `closed` set
+      to `right` and `labels` set to `left`, resulting labels do not fall in
+      bins. Such a result cannot be achieved with `tcut`. Labels returned by
+      `tcut` always fall in time bins. The motivation is that then, a `groupby`
+      can be achieved in a 2nd step with same grouper to provide expected
+      results.
+    - To use results in a `groupby` operation while re-using provided grouper,
+      labels (being categories), need to be materialized again as timestamps
+      with ``astype('datetime64')``.
+    """
+    start, end = gtre(
+        first=data.iloc[0],
+        last=data.iloc[-1],
+        freq=grouper.freq,
+        closed=grouper.closed,
+        origin=grouper.origin,
+        offset=grouper.offset,
+    )
+    # Shifting end by one more period to generate all required bins.
+    end += grouper.freq
+    bins = date_range(start, end, freq=grouper.freq)
+    as_binned = cut(data, bins, right=(grouper.closed == "right"))
+    if grouper.closed == "right":
+        # If closed on 'right', change label of bin so that the label fall in
+        # expected bin.
+        return as_binned.cat.rename_categories(as_binned.cat.categories.right)
+    else:
+        return as_binned.cat.rename_categories(as_binned.cat.categories.left)

--- a/oups/writer.py
+++ b/oups/writer.py
@@ -553,7 +553,9 @@ def write(
     # Manage metadata, whatever the case, initiating new dataset or updating
     # existing one.
     if OUPS_METADATA:
-        if md_key and OUPS_METADATA[md_key] or md_key is None:
+        # If 'md_key' is 'None', then metadata are directly data to be stored
+        # for provided key.
+        if md_key and md_key in OUPS_METADATA and OUPS_METADATA[md_key] or md_key is None:
             metadata = _update_metadata(metadata, pf.key_value_metadata, md_key)
     if metadata:
         update_custom_metadata(pf, metadata)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -20,6 +20,9 @@ from oups import toplevel
 from . import TEST_DATA
 
 
+# tmp_path = os_path.expanduser('~/Documents/code/data/oups')
+
+
 @sublevel
 class SpaceTime:
     area: str

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -51,9 +51,9 @@ def test_oups_metadata_wo_custom_metadata(tmp_path):
     # Step 1: write.
     pdf = pDataFrame({"a": [1], "b": [2]})
     metadata = {"md1": "step1", "md2": "step1", "md3": "step1"}
-    OUPS_METADATA.update(metadata)
     store = ParquetSet(tmp_path, ShortIndexer)
     sidx = ShortIndexer("sidx")
+    OUPS_METADATA[sidx] = metadata
     store[sidx] = pdf
     # Retrieve oups metadata.
     md_rec = store[sidx]._oups_metadata
@@ -62,7 +62,7 @@ def test_oups_metadata_wo_custom_metadata(tmp_path):
     assert not OUPS_METADATA
     # Step 2: update.
     metadata = {"md1": None, "md2": "step2", "md4": "step2"}
-    OUPS_METADATA.update(metadata)
+    OUPS_METADATA[sidx] = metadata
     store[sidx] = pdf
     # Retrieve oups metadata.
     md_rec = store[sidx]._oups_metadata
@@ -76,10 +76,10 @@ def test_oups_metadata_with_custom_metadata(tmp_path):
     # with user-defined metadata.
     # Step 1: write.
     pdf = pDataFrame({"a": [1], "b": [2]})
-    metadata = {"md1": "step1", "md2": "step1", "md3": "step1"}
-    OUPS_METADATA.update(metadata)
     store = ParquetSet(tmp_path, ShortIndexer)
     sidx = ShortIndexer("sidx")
+    metadata = {"md1": "step1", "md2": "step1", "md3": "step1"}
+    OUPS_METADATA[sidx] = metadata
     store[sidx] = {"metadata": metadata.copy()}, pdf
     # Retrieve oups metadata.
     md_rec = store[sidx]._oups_metadata
@@ -94,7 +94,7 @@ def test_oups_metadata_with_custom_metadata(tmp_path):
     assert md_rec == metadata
     # Step 2: update.
     metadata = {"md1": None, "md2": "step2", "md4": "step2"}
-    OUPS_METADATA.update(metadata)
+    OUPS_METADATA[sidx] = metadata
     store[sidx] = {"metadata": metadata.copy()}, pdf
     # Retrieve oups metadata.
     md_rec = store[sidx]._oups_metadata

--- a/tests/test_streamagg.py
+++ b/tests/test_streamagg.py
@@ -36,8 +36,8 @@ class Indexer:
     dataset_ref: str
 
 
-@pytest.mark.parametrize("reduction", [False, True])
-def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
     # Test with parquet seed, time grouper and 'sum' aggregation.
     # No post.
     # Creation & 1st append, 'discard_last=True',
@@ -114,7 +114,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
-        reduction=reduction,
+        reduction=reduction1,
     )
     # Check number of rows of each row groups in aggregated results.
     pf_res = store[key].pf
@@ -177,7 +177,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
-        reduction=reduction,
+        reduction=reduction2,
     )
     # Check number of rows of each row groups in aggregated results.
     pf_res = store[key].pf
@@ -234,7 +234,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction):
         by=by,
         discard_last=False,
         max_row_group_size=max_row_group_size,
-        reduction=reduction,
+        reduction=reduction2,
     )
     # Test results (not trimming seed data).
     ref_res = seed.to_pandas().groupby(by).agg(**agg).reset_index()
@@ -250,7 +250,8 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction):
     assert last_seed_index_res == ts[-1]
 
 
-def test_vaex_seed_time_grouper_sum_agg(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_vaex_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
     # Test with parquet seed, time grouper and 'sum' aggregation.
     # No post.
     # The 1st append, 'discard_last=True', 2nd append, 'discard_last=False'.
@@ -322,6 +323,7 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Check number of rows of each row groups in aggregated results.
     pf_res = store[key].pf
@@ -385,6 +387,7 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path):
         by=by,
         discard_last=False,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Check aggregated results: last row has not been discarded.
     agg_sum_ref = [3, 7, 18, 17, 33, 42, 33, 3]
@@ -414,7 +417,8 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path):
     assert last_seed_index_res == last_seed_index_ref
 
 
-def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path, reduction1, reduction2):
     # Test with parquet seed, time grouper and 'first', 'last', 'min', and
     # 'max' aggregation. No post, 'discard_last=True'.
     # 'Stress test' with appending new data twice.
@@ -453,6 +457,7 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Test results
     ref_res = seed_df.iloc[:-2].groupby(by).agg(**agg).reset_index()
@@ -476,6 +481,7 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Test results
     ref_res = pconcat([seed_df, seed_df2]).iloc[:-1].groupby(by).agg(**agg).reset_index()
@@ -499,6 +505,7 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Test results
     ref_res = pconcat([seed_df, seed_df2, seed_df3]).iloc[:-1].groupby(by).agg(**agg).reset_index()
@@ -509,7 +516,8 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path):
     assert n_rows_res == n_rows_ref
 
 
-def test_vaex_seed_time_grouper_first_last_min_max_agg(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_vaex_seed_time_grouper_first_last_min_max_agg(tmp_path, reduction1, reduction2):
     # Test with vaex seed, time grouper and 'first', 'last', 'min', and
     # 'max' aggregation. No post, 'discard_last=True'. 'Stress test' with
     # appending new data twice.
@@ -548,6 +556,7 @@ def test_vaex_seed_time_grouper_first_last_min_max_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Test results
     ref_res = seed_pdf.iloc[:-2].groupby(by).agg(**agg).reset_index()
@@ -568,6 +577,7 @@ def test_vaex_seed_time_grouper_first_last_min_max_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Test results
     ref_res = pconcat([seed_pdf, seed_pdf2]).iloc[:-1].groupby(by).agg(**agg).reset_index()
@@ -588,6 +598,7 @@ def test_vaex_seed_time_grouper_first_last_min_max_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Test results
     ref_res = (
@@ -600,7 +611,8 @@ def test_vaex_seed_time_grouper_first_last_min_max_agg(tmp_path):
     assert n_rows_res == n_rows_ref
 
 
-def test_parquet_seed_duration_weighted_mean_from_post(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_parquet_seed_duration_weighted_mean_from_post(tmp_path, reduction1, reduction2):
     # Test with parquet seed, time grouper and assess with 'post':
     #  - assess a 'duration' with 'first' and 'last' aggregation,
     #  - assess a 'weighted mean' by using 'sum' aggregation,
@@ -718,6 +730,7 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path):
         post=post,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Check resulting dataframe.
     # Get reference results, discarding last row, because of 'discard_last'.
@@ -774,6 +787,7 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path):
         post=post,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Test results
     ref_res_agg = pconcat([seed_df, seed_df2]).iloc[:-1].groupby(by).agg(**agg).reset_index()
@@ -782,7 +796,8 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path):
     assert rec_res.equals(ref_res_post)
 
 
-def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path, reduction1, reduction2):
     # Test with parquet seed, time grouper and 'first' aggregation.
     # No post, 'discard_last=True'.
     # Change group keys column name with 'bin_on' set as a tuple.
@@ -843,6 +858,7 @@ def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path):
         bin_on=(bin_on, ts_open),
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Test results
     ref_res = seed_pdf.iloc[:-1].groupby(by).agg(**agg)
@@ -869,6 +885,7 @@ def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path):
         trim_start=True,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Test results
     ref_res = pconcat([seed_pdf, seed_pdf2]).iloc[:-1].groupby(by).agg(**agg)
@@ -878,7 +895,8 @@ def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path):
     assert rec_res.equals(ref_res)
 
 
-def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_vaex_seed_by_callable_wo_bin_on(tmp_path, reduction1, reduction2):
     # Test with vaex seed, binning every 4 rows with 'first', and 'max'
     # aggregation. No post, `discard_last` set `True`.
     # Additionally, shows an example of how 'by' as callable can output a
@@ -984,6 +1002,7 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed = seed_pdf.iloc[:-2]
@@ -1049,6 +1068,7 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed2 = seed_pdf2.iloc[:-2]
@@ -1070,7 +1090,8 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
     assert binning_buffer_res2 == binning_buffer_ref2
 
 
-def test_vaex_seed_by_callable_with_bin_on(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
     # Test with vaex seed, binning every time a '1' appear in column 'val'.
     # `discard_last` set `True`.
     # Additionally, show an example of how 'bin_on' as a tuple is used to
@@ -1172,6 +1193,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path):
         bin_on=(bin_on, bin_out_col),
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction1,
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed = seed_pdf.iloc[:-2]
@@ -1221,6 +1243,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path):
         bin_on=(bin_on, bin_out_col),
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction2,
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed2 = seed_pdf2.iloc[:-2]
@@ -1245,7 +1268,8 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path):
     assert binning_buffer_res2 == binning_buffer_ref2
 
 
-def test_parquet_seed_time_grouper_trim_start(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_parquet_seed_time_grouper_trim_start(tmp_path, reduction1, reduction2):
     # Test with parquet seed, time grouper and 'first' aggregation.
     # No post, 'discard_last=True'.
     # Test 'trim_start=False' when appending.
@@ -1273,6 +1297,7 @@ def test_parquet_seed_time_grouper_trim_start(tmp_path):
         by=by,
         trim_start=True,
         discard_last=True,
+        reduction=reduction1,
     )
     # Test results.
     ref_res = seed_pdf.iloc[:-1].groupby(by).agg(**agg).reset_index()
@@ -1298,6 +1323,7 @@ def test_parquet_seed_time_grouper_trim_start(tmp_path):
         by=by,
         trim_start=False,
         discard_last=True,
+        reduction=reduction2,
     )
     # Test results.
     seed_pdf_ref = pconcat([seed_pdf.iloc[:-1], seed_pdf2])
@@ -1306,7 +1332,8 @@ def test_parquet_seed_time_grouper_trim_start(tmp_path):
     assert rec_res.equals(ref_res)
 
 
-def test_vaex_seed_time_grouper_trim_start(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_vaex_seed_time_grouper_trim_start(tmp_path, reduction1, reduction2):
     # Test with vaex seed, time grouper and 'first' aggregation.
     # No post, 'discard_last=True'.
     # Test 'trim_start=False' when appending.
@@ -1332,6 +1359,7 @@ def test_vaex_seed_time_grouper_trim_start(tmp_path):
         by=by,
         trim_start=True,
         discard_last=True,
+        reduction=reduction1,
     )
     # Test results.
     ref_res = seed_pdf.iloc[:-1].groupby(by).agg(**agg).reset_index()
@@ -1355,6 +1383,7 @@ def test_vaex_seed_time_grouper_trim_start(tmp_path):
         by=by,
         trim_start=False,
         discard_last=True,
+        reduction=reduction2,
     )
     # Test results.
     seed_pdf_ref = pconcat([seed_pdf.iloc[:-1], seed_pdf2])
@@ -1363,7 +1392,8 @@ def test_vaex_seed_time_grouper_trim_start(tmp_path):
     assert rec_res.equals(ref_res)
 
 
-def test_vaex_seed_time_grouper_agg_first(tmp_path):
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_vaex_seed_time_grouper_agg_first(tmp_path, reduction1, reduction2):
     # Test with vaex seed, time grouper and 'first' aggregation.
     # No post, 'discard_last=True'.
     # 1st agg ends on a full bin (no stitching required when re-starting).
@@ -1381,7 +1411,15 @@ def test_vaex_seed_time_grouper_agg_first(tmp_path):
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
     # Streamed aggregation.
-    streamagg(seed=seed_vdf, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by)
+    streamagg(
+        seed=seed_vdf,
+        ordered_on=ordered_on,
+        agg=agg,
+        store=store,
+        key=key,
+        by=by,
+        reduction=reduction1,
+    )
     # Test results.
     ref_res = seed_pdf.iloc[:-1].groupby(by).agg(**agg).reset_index()
     rec_res = store[key].pdf
@@ -1392,14 +1430,23 @@ def test_vaex_seed_time_grouper_agg_first(tmp_path):
     seed_pdf2 = pconcat([seed_pdf, seed_pdf2])
     seed_vdf2 = from_pandas(seed_pdf2)
     # Streamed aggregation.
-    streamagg(seed=seed_vdf2, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by)
+    streamagg(
+        seed=seed_vdf2,
+        ordered_on=ordered_on,
+        agg=agg,
+        store=store,
+        key=key,
+        by=by,
+        reduction=reduction2,
+    )
     # Test results.
     ref_res = seed_pdf2.iloc[:-1].groupby(by).agg(**agg).reset_index()
     rec_res = store[key].pdf
     assert rec_res.equals(ref_res)
 
 
-def test_vaex_seed_single_row(tmp_path):
+@pytest.mark.parametrize("reduction", [False, True])
+def test_vaex_seed_single_row(tmp_path, reduction):
     # Test with vaex seed, time grouper and 'first' aggregation.
     # Single row.
     # No post, 'discard_last=True'.
@@ -1416,12 +1463,21 @@ def test_vaex_seed_single_row(tmp_path):
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
     # Streamed aggregation: no aggregation, but no error message.
-    streamagg(seed=seed_vdf, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by)
+    streamagg(
+        seed=seed_vdf,
+        ordered_on=ordered_on,
+        agg=agg,
+        store=store,
+        key=key,
+        by=by,
+        reduction=reduction,
+    )
     # Test results.
     assert key not in store
 
 
-def test_parquet_seed_single_row(tmp_path):
+@pytest.mark.parametrize("reduction", [False, True])
+def test_parquet_seed_single_row(tmp_path, reduction):
     # Test with parquet seed, time grouper and 'first' aggregation.
     # Single row.
     # No post, 'discard_last=True'.
@@ -1440,12 +1496,15 @@ def test_parquet_seed_single_row(tmp_path):
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
     # Streamed aggregation: no aggregation, but no error message.
-    streamagg(seed=seed, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by)
+    streamagg(
+        seed=seed, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by, reduction=reduction
+    )
     # Test results.
     assert key not in store
 
 
-def test_parquet_seed_single_row_within_seed(tmp_path):
+@pytest.mark.parametrize("reduction", [False, True])
+def test_parquet_seed_single_row_within_seed(tmp_path, reduction):
     # Test with parquet seed, time grouper and 'first' aggregation.
     # Single row in the middle of otherwise larger chunks.
     # No post, 'discard_last=True'.
@@ -1509,7 +1568,9 @@ def test_parquet_seed_single_row_within_seed(tmp_path):
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
     # Streamed aggregation: no aggregation, but no error message.
-    streamagg(seed=seed, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by)
+    streamagg(
+        seed=seed, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by, reduction=reduction
+    )
     # Test results.
     ref_res = seed_pdf.iloc[:-2].groupby(by).agg(**agg).reset_index()
     rec_res = store[key].pdf
@@ -1539,7 +1600,8 @@ def test_bin_on_exception(tmp_path):
         streamagg(seed=seed, ordered_on=ordered_on, agg=agg, store=store, key=key, by=by)
 
 
-def test_vaex_seed_time_grouper_duplicates_on_wo_bin_on(tmp_path):
+@pytest.mark.parametrize("reduction", [False, True])
+def test_vaex_seed_time_grouper_duplicates_on_wo_bin_on(tmp_path, reduction):
     # Test with vaex seed, time grouper and 'first' aggregation.
     # No post, 'discard_last=True'.
     # Test 'duplicates_on=[ordered_on]' (without 'bin_on')
@@ -1581,6 +1643,7 @@ def test_vaex_seed_time_grouper_duplicates_on_wo_bin_on(tmp_path):
         post=post,
         discard_last=True,
         duplicates_on=[],
+        reduction=reduction,
     )
     # Test results.
     ref_res = (

--- a/tests/test_streamagg.py
+++ b/tests/test_streamagg.py
@@ -139,8 +139,8 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path):
     # Check 'last_seed_index' is last timestamp.
     (
         last_seed_index_res,
-        binning_buffer_res,
         last_agg_row_res,
+        binning_buffer_res,
         post_buffer_res,
     ) = _get_streamagg_md(store[key])
     last_seed_index_ref = ts[-1]
@@ -202,8 +202,8 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path):
     # Check 'last_seed_index' is last timestamp.
     (
         last_seed_index_res,
-        binning_buffer_res,
         last_agg_row_res,
+        binning_buffer_res,
         post_buffer_res,
     ) = _get_streamagg_md(store[key])
     last_seed_index_ref = ts[-1]
@@ -345,8 +345,8 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path):
     # 'discard_last').
     (
         last_seed_index_res,
-        binning_buffer_res,
         last_agg_row_res,
+        binning_buffer_res,
         post_buffer_res,
     ) = _get_streamagg_md(store[key])
     last_seed_index_ref = ts[-1]
@@ -729,8 +729,8 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path):
     # Check metadata.
     (
         last_seed_index_res,
-        binning_buffer_res,
         last_agg_row_res,
+        binning_buffer_res,
         post_buffer_res,
     ) = _get_streamagg_md(store[key])
     last_seed_index_ref = ts[-1]
@@ -991,8 +991,8 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
     # Check metadata.
     (
         last_seed_index_res,
-        binning_buffer_res,
         last_agg_row_res,
+        binning_buffer_res,
         post_buffer_res,
     ) = _get_streamagg_md(store[key])
     last_seed_index_ref = ts[-1]
@@ -1056,8 +1056,8 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
     # Check binning buffer stored in metadata.
     (
         last_seed_index_res2,
-        binning_buffer_res2,
         _,
+        binning_buffer_res2,
         _,
     ) = _get_streamagg_md(store[key])
     last_seed_index_ref2 = ts2[-1]
@@ -1231,8 +1231,8 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path):
     # Check binning buffer stored in metadata.
     (
         last_seed_index_res2,
-        binning_buffer_res2,
         _,
+        binning_buffer_res2,
         _,
     ) = _get_streamagg_md(store[key])
     last_seed_index_ref2 = ts2[-1]

--- a/tests/test_streamagg.py
+++ b/tests/test_streamagg.py
@@ -99,7 +99,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg_col = "sum"
@@ -308,7 +308,7 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg_col = "sum"
@@ -438,7 +438,7 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path, reduction1, 
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="5T", closed="left", label="left")
     agg = {
@@ -537,7 +537,7 @@ def test_vaex_seed_time_grouper_first_last_min_max_agg(tmp_path, reduction1, red
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="5T", closed="left", label="left")
     agg = {
@@ -677,7 +677,7 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path, reduction1, red
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {
@@ -827,7 +827,7 @@ def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path, reduction1, reducti
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=bin_on, freq="1H", closed="left", label="left")
     agg = {ordered_on: (ordered_on, "last"), "sum": ("val", "sum")}
@@ -958,10 +958,10 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
 
     # Setup binning.
-    def by(data: Series, buffer: dict):
+    def by_4rows(data: Series, buffer: dict):
         """Bin by group of 4 rows. Label for bins are values from `ordered_on`."""
         # A pandas Series is returned, with name being that of the 'ordered_on'
         # column. Because of pandas magic, this column will then be in aggregation
@@ -999,14 +999,14 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path, reduction1, reduction2):
         agg=agg,
         store=store,
         key=key,
-        by=by,
+        by=by_4rows,
         discard_last=True,
         max_row_group_size=max_row_group_size,
         reduction=reduction1,
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed = seed_pdf.iloc[:-2]
-    bins = by(trimmed_seed[ordered_on], {})
+    bins = by_4rows(trimmed_seed[ordered_on], {})
     ref_res_agg = seed_pdf.iloc[:-2].groupby(bins).agg(**agg).reset_index()
     # Test results
     rec_res = store[key].pdf
@@ -1065,14 +1065,14 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path, reduction1, reduction2):
         agg=agg,
         store=store,
         key=key,
-        by=by,
+        by=by_4rows,
         discard_last=True,
         max_row_group_size=max_row_group_size,
         reduction=reduction2,
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed2 = seed_pdf2.iloc[:-2]
-    bins = by(trimmed_seed2[ordered_on], {})
+    bins = by_4rows(trimmed_seed2[ordered_on], {})
     ref_res_agg2 = seed_pdf2.iloc[:-1].groupby(bins).agg(**agg).reset_index()
     # Test results
     rec_res2 = store[key].pdf
@@ -1156,10 +1156,10 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
 
     # Setup binning.
-    def by(data: pDataFrame, buffer: dict):
+    def by_1val(data: pDataFrame, buffer: dict):
         """Start a new bin each time a 1 is spot."""
         # A pandas Series is returned.
         # Its name does not matter as 'bin_on' in streamagg is a tuple which
@@ -1189,7 +1189,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
         agg=agg,
         store=store,
         key=key,
-        by=by,
+        by=by_1val,
         bin_on=(bin_on, bin_out_col),
         discard_last=True,
         max_row_group_size=max_row_group_size,
@@ -1197,7 +1197,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed = seed_pdf.iloc[:-2]
-    bins = by(trimmed_seed[[ordered_on, bin_on]], {})
+    bins = by_1val(trimmed_seed[[ordered_on, bin_on]], {})
     ref_res_agg = seed_pdf.iloc[:-2].groupby(bins).agg(**agg)
     ref_res_agg.index.name = bin_out_col
     ref_res_agg.reset_index(inplace=True)
@@ -1239,7 +1239,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
         agg=agg,
         store=store,
         key=key,
-        by=by,
+        by=by_1val,
         bin_on=(bin_on, bin_out_col),
         discard_last=True,
         max_row_group_size=max_row_group_size,
@@ -1247,7 +1247,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed2 = seed_pdf2.iloc[:-2]
-    bins = by(trimmed_seed2[[ordered_on, bin_on]], {})
+    bins = by_1val(trimmed_seed2[[ordered_on, bin_on]], {})
     ref_res_agg2 = seed_pdf2.iloc[:-1].groupby(bins).agg(**agg)
     ref_res_agg2.index.name = bin_out_col
     ref_res_agg2.reset_index(inplace=True)
@@ -1283,7 +1283,7 @@ def test_parquet_seed_time_grouper_trim_start(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
@@ -1345,7 +1345,7 @@ def test_vaex_seed_time_grouper_trim_start(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
@@ -1406,7 +1406,7 @@ def test_vaex_seed_time_grouper_agg_first(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
@@ -1458,7 +1458,7 @@ def test_vaex_seed_single_row(tmp_path, reduction):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
@@ -1491,7 +1491,7 @@ def test_parquet_seed_single_row(tmp_path, reduction):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
@@ -1563,7 +1563,7 @@ def test_parquet_seed_single_row_within_seed(tmp_path, reduction):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
@@ -1591,7 +1591,7 @@ def test_bin_on_exception(tmp_path):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=bin_on, freq="1H", closed="left", label="left")
     agg = {bin_on: ("val", "sum")}
@@ -1617,7 +1617,7 @@ def test_vaex_seed_time_grouper_duplicates_on_wo_bin_on(tmp_path, reduction):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=bin_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "sum")}
@@ -1664,7 +1664,7 @@ def test_exception_unknown_agg_function(tmp_path):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     by = Grouper(key=ordered_on, freq="1H", closed="left", label="left")
     agg = {"sum": ("val", "unknown")}
@@ -1683,7 +1683,7 @@ def test_exception_not_key_of_streamagg_results(tmp_path):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Store some data using 'key'.
     store[key] = seed_vdf
     # Setup aggregation.
@@ -1729,7 +1729,7 @@ def test_vaex_seed_bin_on_col_sum_agg(tmp_path, reduction1, reduction2):
     # Setup oups parquet collection and key.
     store_path = os_path.join(tmp_path, "store")
     store = ParquetSet(store_path, Indexer)
-    key = Indexer("seed")
+    key = Indexer("agg_res")
     # Setup aggregation.
     agg_col = "sum"
     agg = {agg_col: ("val", "sum")}

--- a/tests/test_streamagg.py
+++ b/tests/test_streamagg.py
@@ -36,7 +36,8 @@ class Indexer:
     dataset_ref: str
 
 
-def test_parquet_seed_time_grouper_sum_agg(tmp_path):
+@pytest.mark.parametrize("reduction", [False, True])
+def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction):
     # Test with parquet seed, time grouper and 'sum' aggregation.
     # No post.
     # Creation & 1st append, 'discard_last=True',
@@ -113,6 +114,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction,
     )
     # Check number of rows of each row groups in aggregated results.
     pf_res = store[key].pf
@@ -175,6 +177,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path):
         by=by,
         discard_last=True,
         max_row_group_size=max_row_group_size,
+        reduction=reduction,
     )
     # Check number of rows of each row groups in aggregated results.
     pf_res = store[key].pf
@@ -231,6 +234,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path):
         by=by,
         discard_last=False,
         max_row_group_size=max_row_group_size,
+        reduction=reduction,
     )
     # Test results (not trimming seed data).
     ref_res = seed.to_pandas().groupby(by).agg(**agg).reset_index()

--- a/tests/test_streamagg.py
+++ b/tests/test_streamagg.py
@@ -939,15 +939,15 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
     key = Indexer("seed")
 
     # Setup binning.
-    def by(data: pDataFrame, buffer: dict):
+    def by(data: Series, buffer: dict):
         """Bin by group of 4 rows. Label for bins are values from `ordered_on`."""
         # A pandas Series is returned, with name being that of the 'ordered_on'
         # column. Because of pandas magic, this column will then be in aggregation
         # results, and oups will be able to use it for writing data.
         # With actual setting, without this trick, 'streamagg' could not write
-        # the results (no 'ordered_on' columnin results).
-        ordered_on = data.columns[0]
-        group_keys = data.copy()
+        # the results (no 'ordered_on' column in results).
+        ordered_on = data.name
+        group_keys = pDataFrame(data)
         # Setup 1st key of groups from previous binning.
         row_offset = 4 - buffer["row_offset"] if "row_offset" in buffer else 0
         group_keys["tmp"] = data.iloc[row_offset::4]
@@ -983,7 +983,7 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed = seed_pdf.iloc[:-2]
-    bins = by(trimmed_seed[[ordered_on]], {})
+    bins = by(trimmed_seed[ordered_on], {})
     ref_res_agg = seed_pdf.iloc[:-2].groupby(bins).agg(**agg).reset_index()
     # Test results
     rec_res = store[key].pdf
@@ -1048,7 +1048,7 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path):
     )
     # Get reference results, discarding last row, because of 'discard_last'.
     trimmed_seed2 = seed_pdf2.iloc[:-2]
-    bins = by(trimmed_seed2[[ordered_on]], {})
+    bins = by(trimmed_seed2[ordered_on], {})
     ref_res_agg2 = seed_pdf2.iloc[:-1].groupby(bins).agg(**agg).reset_index()
     # Test results
     rec_res2 = store[key].pdf

--- a/tests/test_streamagg2.py
+++ b/tests/test_streamagg2.py
@@ -165,7 +165,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "agg_res_len": None,
             "isfbn": True,
             "cols_to_by": None,
-            "by": None,
+            "by": ordered_on_spec,
             "bins": ordered_on_spec,
             "bin_out_col": ordered_on_spec,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
@@ -326,7 +326,7 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "agg_res_len": None,
             "isfbn": True,
             "cols_to_by": None,
-            "by": None,
+            "by": ordered_on_spec,
             "bins": ordered_on_spec,
             "bin_out_col": ordered_on_spec,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
@@ -373,6 +373,28 @@ def test_setup_exception_no_bin_on_nor_by(tmp_path):
     }
     # Test.
     with pytest.raises(ValueError, match="^at least one among"):
+        (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
+            **parameter_in
+        )
+
+
+def test_setup_exception_no_bin_on_nor_by_key_when_grouper(tmp_path):
+    ordered_on = "ts"
+    key = Indexer("agg_res")
+    store_path = os_path.join(tmp_path, "store")
+    store = ParquetSet(store_path, Indexer)
+    keys_config = {key: {"agg": {"out_spec": ("in_spec", "first")}, "by": Grouper(freq="1H")}}
+    parameter_in = {
+        "store": store,
+        "keys": keys_config,
+        "ordered_on": ordered_on,
+        "trim_start": True,
+        "agg": None,
+        "post": None,
+        "reduction": True,
+    }
+    # Test.
+    with pytest.raises(ValueError, match="^no column name defined to bin"):
         (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
             **parameter_in
         )

--- a/tests/test_streamagg2.py
+++ b/tests/test_streamagg2.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""
+Created on Sun Mar 13 18:00:00 2022.
+
+@author: yoh
+"""
+from os import path as os_path
+
+import pytest
+from pandas import DataFrame as pDataFrame
+from pandas import Grouper
+
+from oups import ParquetSet
+from oups import toplevel
+from oups.streamagg import _setup
+from oups.writer import MAX_ROW_GROUP_SIZE
+
+
+# from pandas.testing import assert_frame_equal
+# tmp_path = os_path.expanduser('~/Documents/code/data/oups')
+
+
+@toplevel
+class Indexer:
+    dataset_ref: str
+
+
+def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
+    # Test config for each key and for seed is correctly consolidated,
+    # with default values when parameters are not specified at key level.
+    # 'max_row_group_size' and 'max_nirgs' are default parameters for writing.
+    # 'post' also has a default value.
+    # Key 1 has mostly parameters defined by default values.
+    # Key 2 has mostly parameters defined by specific values.
+    # Keys 3 & 4 have only default parameters, except minimally compulsory
+    # specific parameters.
+    ordered_on_alt = "ts_alt"
+    ordered_on_spec = "ts_spec"
+    ordered_on_dflt = "ts_dflt"
+    key1 = Indexer("some_default")
+    key2 = Indexer("only_specific")
+    key3 = Indexer("only_default1")
+    key4 = Indexer("only_default2")
+    tgrouper = Grouper(key=ordered_on_alt, freq="1H")
+    store_path = os_path.join(tmp_path, "store")
+    store = ParquetSet(store_path, Indexer)
+
+    def dummy_by(**kwargs):
+        # Dummy function for key 2.
+        return True
+
+    def dummy_post_spec(**kwargs):
+        # Dummy function for key 1.
+        return True
+
+    def dummy_post_dflt(**kwargs):
+        # Dummy function for key 1.
+        return True
+
+    keys_config = {
+        key1: {"agg": {"out_spec": ("in_spec", "first")}, "by": tgrouper, "post": dummy_post_spec},
+        key2: {
+            "agg": {"out_spec": ("in_spec", "first")},
+            "by": dummy_by,
+            "post": None,
+            "max_row_group_size": 3000,
+        },
+        key3: {"by": dummy_by},
+        key4: {"bin_on": ordered_on_spec},
+    }
+    trim_start = True
+    parameter_in = {
+        "store": store,
+        "keys": keys_config,
+        "ordered_on": ordered_on_dflt,
+        "trim_start": trim_start,
+        "agg": {"out_dflt": ("in_dflt", "last")},
+        "post": dummy_post_dflt,
+        "reduction": True,
+        "max_row_group_size": 1000,
+        "max_nirgs": 4,
+    }
+    # Test.
+    (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
+        **parameter_in
+    )
+    # Reference results.
+    keys_config_ref = {
+        key1: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": None,
+            "by": tgrouper,
+            "bins": tgrouper,
+            "bin_out_col": ordered_on_alt,
+            "self_agg": {"out_spec": ("out_spec", "first")},
+            "agg": {"out_spec": ("in_spec__first", "first")},
+            "post": dummy_post_spec,
+            "max_agg_row_group_size": 1000,
+            "write_config": {
+                "max_row_group_size": 1000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_alt,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key2: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": [ordered_on_dflt],
+            "by": dummy_by,
+            "bins": None,
+            "bin_out_col": None,
+            "self_agg": {"out_spec": ("out_spec", "first")},
+            "agg": {"out_spec": ("in_spec__first", "first")},
+            "post": None,
+            "max_agg_row_group_size": 3000,
+            "write_config": {
+                "max_row_group_size": 3000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_dflt,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key3: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": [ordered_on_dflt],
+            "by": dummy_by,
+            "bins": None,
+            "bin_out_col": None,
+            "self_agg": {"out_dflt": ("out_dflt", "last")},
+            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "post": dummy_post_dflt,
+            "max_agg_row_group_size": 1000,
+            "write_config": {
+                "max_row_group_size": 1000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_dflt,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key4: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": None,
+            "by": None,
+            "bins": ordered_on_spec,
+            "bin_out_col": ordered_on_spec,
+            "self_agg": {"out_dflt": ("out_dflt", "last")},
+            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "post": dummy_post_dflt,
+            "max_agg_row_group_size": 1000,
+            "write_config": {
+                "max_row_group_size": 1000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_spec,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+    }
+    # Check.
+    key1_last_agg_row = keys_config_res[key1].pop("last_agg_row")
+    assert key1_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key1] == keys_config_res[key1]
+    key2_last_agg_row = keys_config_res[key2].pop("last_agg_row")
+    assert key2_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key2] == keys_config_res[key2]
+    key3_last_agg_row = keys_config_res[key3].pop("last_agg_row")
+    assert key3_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key3] == keys_config_res[key3]
+    key4_last_agg_row = keys_config_res[key4].pop("last_agg_row")
+    assert key4_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key4] == keys_config_res[key4]
+    assert not seed_index_restart_set
+    assert not trim_start
+
+
+def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
+    # Test config for each key and for seed is correctly consolidated,
+    # with default values when parameters are not specified at key level.
+    # 'max_row_group_size' and 'max_nirgs' are not provided for writing.
+    # 'post' also has no default value either.
+    # Key 1 has mostly parameters defined by default values.
+    # Key 2 has mostly parameters defined by specific values.
+    # Keys 3 & 4 have only default parameters, except minimally compulsory
+    # specific parameters.
+    ordered_on_alt = "ts_alt"
+    ordered_on_spec = "ts_spec"
+    ordered_on_dflt = "ts_dflt"
+    key1 = Indexer("some_default")
+    key2 = Indexer("only_specific")
+    key3 = Indexer("only_default1")
+    key4 = Indexer("only_default2")
+    tgrouper = Grouper(key=ordered_on_alt, freq="1H")
+    store_path = os_path.join(tmp_path, "store")
+    store = ParquetSet(store_path, Indexer)
+
+    def dummy_by(**kwargs):
+        # Dummy function for key 2.
+        return True
+
+    def dummy_post_spec(**kwargs):
+        # Dummy function for key 1.
+        return True
+
+    def dummy_post_dflt(**kwargs):
+        # Dummy function for key 1.
+        return True
+
+    keys_config = {
+        key1: {"agg": {"out_spec": ("in_spec", "first")}, "by": tgrouper, "post": dummy_post_spec},
+        key2: {
+            "agg": {"out_spec": ("in_spec", "first")},
+            "by": dummy_by,
+            "max_row_group_size": 3000,
+        },
+        key3: {"by": dummy_by},
+        key4: {"bin_on": ordered_on_spec},
+    }
+    trim_start = True
+    parameter_in = {
+        "store": store,
+        "keys": keys_config,
+        "ordered_on": ordered_on_dflt,
+        "trim_start": trim_start,
+        "agg": {"out_dflt": ("in_dflt", "last")},
+        "reduction": True,
+        "post": None,
+    }
+    # Test.
+    (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
+        **parameter_in
+    )
+    # Reference results.
+    keys_config_ref = {
+        key1: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": None,
+            "by": tgrouper,
+            "bins": tgrouper,
+            "bin_out_col": ordered_on_alt,
+            "self_agg": {"out_spec": ("out_spec", "first")},
+            "agg": {"out_spec": ("in_spec__first", "first")},
+            "post": dummy_post_spec,
+            "max_agg_row_group_size": MAX_ROW_GROUP_SIZE,
+            "write_config": {"ordered_on": ordered_on_dflt, "duplicates_on": ordered_on_alt},
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key2: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": [ordered_on_dflt],
+            "by": dummy_by,
+            "bins": None,
+            "bin_out_col": None,
+            "self_agg": {"out_spec": ("out_spec", "first")},
+            "agg": {"out_spec": ("in_spec__first", "first")},
+            "post": None,
+            "max_agg_row_group_size": 3000,
+            "write_config": {
+                "max_row_group_size": 3000,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_dflt,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key3: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": [ordered_on_dflt],
+            "by": dummy_by,
+            "bins": None,
+            "bin_out_col": None,
+            "self_agg": {"out_dflt": ("out_dflt", "last")},
+            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "post": None,
+            "max_agg_row_group_size": MAX_ROW_GROUP_SIZE,
+            "write_config": {"ordered_on": ordered_on_dflt, "duplicates_on": ordered_on_dflt},
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key4: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": None,
+            "by": None,
+            "bins": ordered_on_spec,
+            "bin_out_col": ordered_on_spec,
+            "self_agg": {"out_dflt": ("out_dflt", "last")},
+            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "post": None,
+            "max_agg_row_group_size": MAX_ROW_GROUP_SIZE,
+            "write_config": {"ordered_on": ordered_on_dflt, "duplicates_on": ordered_on_spec},
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+    }
+    # Check.
+    key1_last_agg_row = keys_config_res[key1].pop("last_agg_row")
+    assert key1_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key1] == keys_config_res[key1]
+    key2_last_agg_row = keys_config_res[key2].pop("last_agg_row")
+    assert key2_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key2] == keys_config_res[key2]
+    key3_last_agg_row = keys_config_res[key3].pop("last_agg_row")
+    assert key3_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key3] == keys_config_res[key3]
+    key4_last_agg_row = keys_config_res[key4].pop("last_agg_row")
+    assert key4_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key4] == keys_config_res[key4]
+    assert not seed_index_restart_set
+    assert not trim_start
+
+
+def test_setup_exception_no_bin_on_nor_by(tmp_path):
+    ordered_on = "ts"
+    key = Indexer("agg_res")
+    store_path = os_path.join(tmp_path, "store")
+    store = ParquetSet(store_path, Indexer)
+    keys_config = {key: {"agg": {"out_spec": ("in_spec", "first")}}}
+    parameter_in = {
+        "store": store,
+        "keys": keys_config,
+        "ordered_on": ordered_on,
+        "trim_start": True,
+        "agg": None,
+        "post": None,
+        "reduction": True,
+    }
+    # Test.
+    with pytest.raises(ValueError, match="^at least one among"):
+        (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
+            **parameter_in
+        )
+
+
+# Test exception when calling streamagg with agg = None & key not a dict: not possible.
+
+# Test exception when, with aggregation restart, seed_index_restart_set has
+# 2 different values (from 2 different agrgegation resultes)
+
+
+# Test maxx row_group_sizedefined in dict of a keys is forwarded in write_config
+# Test some default option vs non default options
+# Check 'reduction_agg' and modified 'agg'

--- a/tests/test_streamagg2.py
+++ b/tests/test_streamagg2.py
@@ -4,6 +4,7 @@ Created on Sun Mar 13 18:00:00 2022.
 
 @author: yoh
 """
+from copy import copy
 from os import path as os_path
 
 import pytest
@@ -76,12 +77,12 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
         "trim_start": trim_start,
         "agg": {"out_dflt": ("in_dflt", "last")},
         "post": dummy_post_dflt,
-        "reduction": True,
+        "reduction": False,
         "max_row_group_size": 1000,
         "max_nirgs": 4,
     }
     # Test.
-    (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
+    (all_cols_in, trim_start, seed_index_restart_set, reduction_agg_res, keys_config_res) = _setup(
         **parameter_in
     )
     # Reference results.
@@ -92,12 +93,12 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": None,
+            "cols_to_by": [ordered_on_dflt, ordered_on_alt],
             "by": tgrouper,
             "bins": tgrouper,
             "bin_out_col": ordered_on_alt,
             "self_agg": {"out_spec": ("out_spec", "first")},
-            "agg": {"out_spec": ("in_spec__first", "first")},
+            "agg": {"out_spec": ("in_spec", "first")},
             "post": dummy_post_spec,
             "max_agg_row_group_size": 1000,
             "write_config": {
@@ -116,12 +117,12 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": [ordered_on_dflt],
+            "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_spec": ("out_spec", "first")},
-            "agg": {"out_spec": ("in_spec__first", "first")},
+            "agg": {"out_spec": ("in_spec", "first")},
             "post": None,
             "max_agg_row_group_size": 3000,
             "write_config": {
@@ -140,12 +141,12 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": [ordered_on_dflt],
+            "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
-            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "agg": {"out_dflt": ("in_dflt", "last")},
             "post": dummy_post_dflt,
             "max_agg_row_group_size": 1000,
             "write_config": {
@@ -164,12 +165,12 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": None,
-            "by": ordered_on_spec,
+            "cols_to_by": [ordered_on_dflt, ordered_on_spec],
+            "by": None,
             "bins": ordered_on_spec,
             "bin_out_col": ordered_on_spec,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
-            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "agg": {"out_dflt": ("in_dflt", "last")},
             "post": dummy_post_dflt,
             "max_agg_row_group_size": 1000,
             "write_config": {
@@ -198,6 +199,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
     assert keys_config_ref[key4] == keys_config_res[key4]
     assert not seed_index_restart_set
     assert not trim_start
+    assert not reduction_agg_res
 
 
 def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
@@ -249,11 +251,11 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
         "ordered_on": ordered_on_dflt,
         "trim_start": trim_start,
         "agg": {"out_dflt": ("in_dflt", "last")},
-        "reduction": True,
+        "reduction": False,
         "post": None,
     }
     # Test.
-    (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
+    (all_cols_in, trim_start, seed_index_restart_set, reduction_agg_res, keys_config_res) = _setup(
         **parameter_in
     )
     # Reference results.
@@ -264,12 +266,12 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": None,
+            "cols_to_by": [ordered_on_dflt, ordered_on_alt],
             "by": tgrouper,
             "bins": tgrouper,
             "bin_out_col": ordered_on_alt,
             "self_agg": {"out_spec": ("out_spec", "first")},
-            "agg": {"out_spec": ("in_spec__first", "first")},
+            "agg": {"out_spec": ("in_spec", "first")},
             "post": dummy_post_spec,
             "max_agg_row_group_size": MAX_ROW_GROUP_SIZE,
             "write_config": {"ordered_on": ordered_on_dflt, "duplicates_on": ordered_on_alt},
@@ -283,12 +285,12 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": [ordered_on_dflt],
+            "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_spec": ("out_spec", "first")},
-            "agg": {"out_spec": ("in_spec__first", "first")},
+            "agg": {"out_spec": ("in_spec", "first")},
             "post": None,
             "max_agg_row_group_size": 3000,
             "write_config": {
@@ -306,12 +308,12 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": [ordered_on_dflt],
+            "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
-            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "agg": {"out_dflt": ("in_dflt", "last")},
             "post": None,
             "max_agg_row_group_size": MAX_ROW_GROUP_SIZE,
             "write_config": {"ordered_on": ordered_on_dflt, "duplicates_on": ordered_on_dflt},
@@ -325,12 +327,12 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "agg_res": None,
             "agg_res_len": None,
             "isfbn": True,
-            "cols_to_by": None,
-            "by": ordered_on_spec,
+            "cols_to_by": [ordered_on_dflt, ordered_on_spec],
+            "by": None,
             "bins": ordered_on_spec,
             "bin_out_col": ordered_on_spec,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
-            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "agg": {"out_dflt": ("in_dflt", "last")},
             "post": None,
             "max_agg_row_group_size": MAX_ROW_GROUP_SIZE,
             "write_config": {"ordered_on": ordered_on_dflt, "duplicates_on": ordered_on_spec},
@@ -352,6 +354,199 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
     key4_last_agg_row = keys_config_res[key4].pop("last_agg_row")
     assert key4_last_agg_row.equals(pDataFrame())
     assert keys_config_ref[key4] == keys_config_res[key4]
+    assert not seed_index_restart_set
+    assert not trim_start
+    assert not reduction_agg_res
+
+
+def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
+    # Test config for each key and for seed is correctly consolidated,
+    # with default values when parameters are not specified at key level.
+    # 'max_row_group_size' and 'max_nirgs' are default parameters for writing.
+    # 'post' also has a default value.
+    # 'reduction' is `True`.
+    # Key 1 has mostly parameters defined by default values.
+    # Key 2 has mostly parameters defined by specific values.
+    # Keys 3 & 4 have only default parameters, except minimally compulsory
+    # specific parameters.
+    ordered_on_alt = "ts_alt"
+    ordered_on_spec = "ts_spec"
+    ordered_on_dflt = "ts_dflt"
+    key1 = Indexer("some_default")
+    key2 = Indexer("only_specific")
+    key3 = Indexer("only_default1")
+    key4 = Indexer("only_default2")
+    tgrouper = Grouper(key=ordered_on_alt, freq="1H")
+    store_path = os_path.join(tmp_path, "store")
+    store = ParquetSet(store_path, Indexer)
+
+    def dummy_by(**kwargs):
+        # Dummy function for key 2.
+        return True
+
+    def dummy_post_spec(**kwargs):
+        # Dummy function for key 1.
+        return True
+
+    def dummy_post_dflt(**kwargs):
+        # Dummy function for key 1.
+        return True
+
+    keys_config = {
+        key1: {"agg": {"out_spec": ("in_spec", "first")}, "by": tgrouper, "post": dummy_post_spec},
+        key2: {
+            "agg": {"out_spec": ("in_spec", "first")},
+            "by": dummy_by,
+            "post": None,
+            "max_row_group_size": 3000,
+        },
+        key3: {"by": dummy_by},
+        key4: {"bin_on": ordered_on_spec},
+    }
+    trim_start = True
+    parameter_in = {
+        "store": store,
+        "keys": keys_config,
+        "ordered_on": ordered_on_dflt,
+        "trim_start": trim_start,
+        "agg": {"out_dflt": ("in_dflt", "last")},
+        "post": dummy_post_dflt,
+        "reduction": True,
+        "max_row_group_size": 1000,
+        "max_nirgs": 4,
+    }
+    # Test.
+    (all_cols_in, trim_start, seed_index_restart_set, reduction_agg_res, keys_config_res) = _setup(
+        **parameter_in
+    )
+    # Reference results.
+    key1_tgrouper = copy(tgrouper)
+    key1_tgrouper.key = "key_0"
+    keys_config_ref = {
+        key1: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": [ordered_on_dflt, ordered_on_alt],
+            "by": tgrouper,
+            "bin_out_col": ordered_on_alt,
+            "self_agg": {"out_spec": ("out_spec", "first")},
+            "agg": {"out_spec": ("in_spec__first", "first")},
+            "post": dummy_post_spec,
+            "max_agg_row_group_size": 1000,
+            "write_config": {
+                "max_row_group_size": 1000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_alt,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key2: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": ordered_on_dflt,
+            "by": dummy_by,
+            "bins": "key_1",
+            "bin_out_col": None,
+            "self_agg": {"out_spec": ("out_spec", "first")},
+            "agg": {"out_spec": ("in_spec__first", "first")},
+            "post": None,
+            "max_agg_row_group_size": 3000,
+            "write_config": {
+                "max_row_group_size": 3000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_dflt,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key3: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": ordered_on_dflt,
+            "by": dummy_by,
+            "bins": "key_2",
+            "bin_out_col": None,
+            "self_agg": {"out_dflt": ("out_dflt", "last")},
+            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "post": dummy_post_dflt,
+            "max_agg_row_group_size": 1000,
+            "write_config": {
+                "max_row_group_size": 1000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_dflt,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+        key4: {
+            "agg_n_rows": 0,
+            "agg_mean_row_group_size": 0,
+            "agg_res": None,
+            "agg_res_len": None,
+            "isfbn": True,
+            "cols_to_by": [ordered_on_dflt, ordered_on_spec],
+            "by": ordered_on_spec,
+            "bins": "key_3",
+            "bin_out_col": ordered_on_spec,
+            "self_agg": {"out_dflt": ("out_dflt", "last")},
+            "agg": {"out_dflt": ("in_dflt__last", "last")},
+            "post": dummy_post_dflt,
+            "max_agg_row_group_size": 1000,
+            "write_config": {
+                "max_row_group_size": 1000,
+                "max_nirgs": 4,
+                "ordered_on": ordered_on_dflt,
+                "duplicates_on": ordered_on_spec,
+            },
+            "binning_buffer": {},
+            "post_buffer": {},
+            "agg_chunks_buffer": [],
+        },
+    }
+    reduction_agg_ref = {
+        "in_spec__first": ("in_spec", "first"),
+        "in_dflt__last": ("in_dflt", "last"),
+    }
+
+    # Check.
+    key1_last_agg_row = keys_config_res[key1].pop("last_agg_row")
+    assert key1_last_agg_row.equals(pDataFrame())
+    key1_bins = keys_config_res[key1].pop("bins")
+    assert key1_bins.__dict__ == key1_tgrouper.__dict__
+    assert keys_config_ref[key1] == keys_config_res[key1]
+    key2_last_agg_row = keys_config_res[key2].pop("last_agg_row")
+    assert key2_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key2] == keys_config_res[key2]
+    key3_last_agg_row = keys_config_res[key3].pop("last_agg_row")
+    assert key3_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key3] == keys_config_res[key3]
+    key4_last_agg_row = keys_config_res[key4].pop("last_agg_row")
+    assert key4_last_agg_row.equals(pDataFrame())
+    assert keys_config_ref[key4] == keys_config_res[key4]
+    assert set(all_cols_in) == {
+        ordered_on_dflt,
+        ordered_on_spec,
+        "in_dflt",
+        "in_spec",
+        ordered_on_alt,
+    }
+    assert reduction_agg_res == reduction_agg_ref
     assert not seed_index_restart_set
     assert not trim_start
 
@@ -398,6 +593,11 @@ def test_setup_exception_no_bin_on_nor_by_key_when_grouper(tmp_path):
         (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
             **parameter_in
         )
+
+
+# Tester que 'bins' si reduction
+#  - si 'by' est callable, récupère nom générique de colonne
+#  - si 'by' est grouper, récupère nolm générique dans attribute 'by'
 
 
 # Test exception when calling streamagg with agg = None & key not a dict: not possible.

--- a/tests/test_streamagg2.py
+++ b/tests/test_streamagg2.py
@@ -13,6 +13,7 @@ from pandas import Grouper
 
 from oups import ParquetSet
 from oups import toplevel
+from oups.streamagg import REDUCTION_BIN_COL_PREFIX
 from oups.streamagg import _setup
 from oups.writer import MAX_ROW_GROUP_SIZE
 
@@ -95,6 +96,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "isfbn": True,
             "cols_to_by": [ordered_on_dflt, ordered_on_alt],
             "by": tgrouper,
+            "reduction_bin_col": None,
             "bins": tgrouper,
             "bin_out_col": ordered_on_alt,
             "self_agg": {"out_spec": ("out_spec", "first")},
@@ -119,6 +121,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "isfbn": True,
             "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
+            "reduction_bin_col": None,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_spec": ("out_spec", "first")},
@@ -143,6 +146,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "isfbn": True,
             "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
+            "reduction_bin_col": None,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
@@ -167,6 +171,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
             "isfbn": True,
             "cols_to_by": [ordered_on_dflt, ordered_on_spec],
             "by": None,
+            "reduction_bin_col": None,
             "bins": ordered_on_spec,
             "bin_out_col": ordered_on_spec,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
@@ -268,6 +273,7 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "isfbn": True,
             "cols_to_by": [ordered_on_dflt, ordered_on_alt],
             "by": tgrouper,
+            "reduction_bin_col": None,
             "bins": tgrouper,
             "bin_out_col": ordered_on_alt,
             "self_agg": {"out_spec": ("out_spec", "first")},
@@ -287,6 +293,7 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "isfbn": True,
             "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
+            "reduction_bin_col": None,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_spec": ("out_spec", "first")},
@@ -310,6 +317,7 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "isfbn": True,
             "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
+            "reduction_bin_col": None,
             "bins": None,
             "bin_out_col": None,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
@@ -329,6 +337,7 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
             "isfbn": True,
             "cols_to_by": [ordered_on_dflt, ordered_on_spec],
             "by": None,
+            "reduction_bin_col": None,
             "bins": ordered_on_spec,
             "bin_out_col": ordered_on_spec,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
@@ -420,8 +429,8 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
         **parameter_in
     )
     # Reference results.
-    key1_tgrouper = copy(tgrouper)
-    key1_tgrouper.key = "key_0"
+    tgrouper_key1_ref = copy(tgrouper)
+    tgrouper_key1_ref.key = f"{REDUCTION_BIN_COL_PREFIX}0"
     keys_config_ref = {
         key1: {
             "agg_n_rows": 0,
@@ -431,6 +440,8 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
             "isfbn": True,
             "cols_to_by": [ordered_on_dflt, ordered_on_alt],
             "by": tgrouper,
+            "reduction_bin_col": f"{REDUCTION_BIN_COL_PREFIX}0",
+            "bins": tgrouper_key1_ref,
             "bin_out_col": ordered_on_alt,
             "self_agg": {"out_spec": ("out_spec", "first")},
             "agg": {"out_spec": ("in_spec__first", "first")},
@@ -454,7 +465,8 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
             "isfbn": True,
             "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
-            "bins": "key_1",
+            "reduction_bin_col": f"{REDUCTION_BIN_COL_PREFIX}1",
+            "bins": f"{REDUCTION_BIN_COL_PREFIX}1",
             "bin_out_col": None,
             "self_agg": {"out_spec": ("out_spec", "first")},
             "agg": {"out_spec": ("in_spec__first", "first")},
@@ -478,7 +490,8 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
             "isfbn": True,
             "cols_to_by": ordered_on_dflt,
             "by": dummy_by,
-            "bins": "key_2",
+            "reduction_bin_col": f"{REDUCTION_BIN_COL_PREFIX}2",
+            "bins": f"{REDUCTION_BIN_COL_PREFIX}2",
             "bin_out_col": None,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
             "agg": {"out_dflt": ("in_dflt__last", "last")},
@@ -502,7 +515,8 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
             "isfbn": True,
             "cols_to_by": [ordered_on_dflt, ordered_on_spec],
             "by": ordered_on_spec,
-            "bins": "key_3",
+            "reduction_bin_col": f"{REDUCTION_BIN_COL_PREFIX}3",
+            "bins": f"{REDUCTION_BIN_COL_PREFIX}3",
             "bin_out_col": ordered_on_spec,
             "self_agg": {"out_dflt": ("out_dflt", "last")},
             "agg": {"out_dflt": ("in_dflt__last", "last")},
@@ -527,8 +541,9 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
     # Check.
     key1_last_agg_row = keys_config_res[key1].pop("last_agg_row")
     assert key1_last_agg_row.equals(pDataFrame())
-    key1_bins = keys_config_res[key1].pop("bins")
-    assert key1_bins.__dict__ == key1_tgrouper.__dict__
+    key1_bins_res = keys_config_res[key1].pop("bins")
+    key1_bins_ref = keys_config_ref[key1].pop("bins")
+    assert key1_bins_res.__dict__ == key1_bins_ref.__dict__
     assert keys_config_ref[key1] == keys_config_res[key1]
     key2_last_agg_row = keys_config_res[key2].pop("last_agg_row")
     assert key2_last_agg_row.equals(pDataFrame())
@@ -598,6 +613,9 @@ def test_setup_exception_no_bin_on_nor_by_key_when_grouper(tmp_path):
 # Tester que 'bins' si reduction
 #  - si 'by' est callable, récupère nom générique de colonne
 #  - si 'by' est grouper, récupère nolm générique dans attribute 'by'
+
+# Test avec 2 keys (sampler) réalisés séparemment puis ensemble: vérifier que chainagg
+# réalise le changement de nom de l'index dans 'last_agg_row' pour redémarrer.
 
 
 # Test exception when calling streamagg with agg = None & key not a dict: not possible.

--- a/tests/test_streamagg2.py
+++ b/tests/test_streamagg2.py
@@ -219,7 +219,6 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
     key4_last_agg_row = keys_config_res[key4].pop("last_agg_row")
     assert key4_last_agg_row.equals(pDataFrame())
     assert keys_config_ref[key4] == keys_config_res[key4]
-    #
     all_cols_in_ref = {"in_spec", ordered_on_dflt, bin_on_spec, ordered_on_alt, "in_dflt"}
     assert set(all_cols_in_res) == all_cols_in_ref
     assert not trim_start
@@ -392,7 +391,6 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
     key4_last_agg_row = keys_config_res[key4].pop("last_agg_row")
     assert key4_last_agg_row.equals(pDataFrame())
     assert keys_config_ref[key4] == keys_config_res[key4]
-    #
     all_cols_in_ref = {"in_spec", ordered_on_dflt, bin_on_spec, ordered_on_alt, "in_dflt"}
     assert set(all_cols_in_res) == all_cols_in_ref
     assert not trim_start
@@ -594,7 +592,6 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
     key4_last_agg_row = keys_config_res[key4].pop("last_agg_row")
     assert key4_last_agg_row.equals(pDataFrame())
     assert keys_config_ref[key4] == keys_config_res[key4]
-    #
     all_cols_in_ref = {"in_spec", ordered_on_dflt, bin_on_spec, ordered_on_alt, "in_dflt"}
     assert set(all_cols_in_res) == all_cols_in_ref
     assert reduction_agg_res == reduction_agg_ref

--- a/tests/test_streamagg2.py
+++ b/tests/test_streamagg2.py
@@ -7,11 +7,19 @@ Created on Sun Mar 13 18:00:00 2022.
 from copy import copy
 from os import path as os_path
 
+import numpy as np
 import pytest
+from fastparquet import ParquetFile
+from fastparquet import write as fp_write
 from pandas import DataFrame as pDataFrame
 from pandas import Grouper
+from pandas import Series
+from pandas import Timedelta
+from pandas import Timestamp
+from pandas import concat as pconcat
 
 from oups import ParquetSet
+from oups import streamagg
 from oups import toplevel
 from oups.streamagg import REDUCTION_BIN_COL_PREFIX
 from oups.streamagg import _setup
@@ -645,6 +653,182 @@ def test_setup_exception_no_bin_on_nor_by_key_when_grouper(tmp_path):
         (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
             **parameter_in
         )
+
+
+@pytest.mark.parametrize("reduction1,reduction2", [(False, False), (True, True), (True, False)])
+def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2):
+    # Test with parquet seed, and 4 keys.
+    # - key 1: time grouper '2T', agg 'first', and 'last',
+    # - key 2: time grouper '13T', agg 'first', and 'max',
+    # - key 3: 'by' as callable, every 4 rows, agg 'min', 'max',
+    # - key 4: 'by' as None, and direct use of a column,
+    #          agg 'first' on 'ordered_on' and on 'val'.
+    max_row_group_size = 6
+    start = Timestamp("2020/01/01")
+    rr = np.random.default_rng(1)
+    N = 24
+    rand_ints = rr.integers(100, size=N)
+    rand_ints.sort()
+    ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
+    N_third = int(N / 3)
+    bin_val = np.array(
+        [1] * (N_third - 2) + [2] * (N_third - 4) + [3] * (N - 2 * N_third) + [4] * 6
+    )
+    ordered_on = "ts"
+    bin_on = "direct_bin"
+    seed_df = pDataFrame({ordered_on: ts, "val": rand_ints, bin_on: bin_val})
+    seed_path = os_path.join(tmp_path, "seed")
+    fp_write(seed_path, seed_df, row_group_offsets=max_row_group_size, file_scheme="hive")
+    seed = ParquetFile(seed_path)
+    # Setup oups parquet collection and key.
+    store_path = os_path.join(tmp_path, "store")
+    store = ParquetSet(store_path, Indexer)
+    key1 = Indexer("agg_2T")
+    key2 = Indexer("agg_13T")
+    key3 = Indexer("agg_4rows")
+    key4 = Indexer("agg_direct_bin")
+
+    # Setup binning for key3.
+    def by_4rows(data: Series, buffer: dict):
+        """Bin by group of 4 rows. Label for bins are values from `ordered_on`."""
+        # A pandas Series is returned, with name being that of the 'ordered_on'
+        # column. Because of pandas magic, this column will then be in aggregation
+        # results, and oups will be able to use it for writing data.
+        # With actual setting, without this trick, 'streamagg' could not write
+        # the results (no 'ordered_on' column in results).
+        ordered_on = data.name
+        group_keys = pDataFrame(data)
+        # Setup 1st key of groups from previous binning.
+        row_offset = 4 - buffer["row_offset"] if "row_offset" in buffer else 0
+        group_keys["tmp"] = data.iloc[row_offset::4]
+        if row_offset and "last_key" in buffer:
+            # Initialize 1st row if row_offset is not 0.
+            group_keys.iloc[0, group_keys.columns.get_loc("tmp")] = buffer["last_key"]
+        group_keys[ordered_on] = group_keys["tmp"].ffill()
+        group_keys = Series(group_keys[ordered_on], name=ordered_on)
+        keys, counts = np.unique(group_keys, return_counts=True)
+        # Update buffer in-place for next binning.
+        if "row_offset" in buffer and buffer["row_offset"] != 4:
+            buffer["row_offset"] = counts[-1] + buffer["row_offset"]
+        else:
+            buffer["row_offset"] = counts[-1]
+        buffer["last_key"] = keys[-1]
+        return group_keys
+
+    # Setup aggregation.
+    key1_cf = {
+        "by": Grouper(key=ordered_on, freq="2T", closed="left", label="left"),
+        "agg": {"first": ("val", "first"), "last": ("val", "last")},
+    }
+    key2_cf = {
+        "by": Grouper(key=ordered_on, freq="13T", closed="left", label="left"),
+        "agg": {"first": ("val", "first"), "max": ("val", "max")},
+    }
+    key3_cf = {
+        "by": Grouper(key=ordered_on, freq="13T", closed="left", label="left"),
+        "agg": {"min": ("val", "min"), "max": ("val", "max")},
+    }
+    key4_cf = {
+        "bin_on": bin_on,
+        "agg": {ordered_on: (ordered_on, "first"), "first": ("val", "first")},
+    }
+    key_configs = {key1: key1_cf, key2: key2_cf, key3: key3_cf, key4: key4_cf}
+    # Setup streamed aggregation.
+    streamagg(
+        seed=seed,
+        ordered_on=ordered_on,
+        store=store,
+        key=key_configs,
+        discard_last=True,
+        max_row_group_size=max_row_group_size,
+        reduction=reduction1,
+    )
+    # Test results
+    # Remove last 'group' as per 'ordered_on' in 'seed_df'.
+    seed_df_trim = seed_df[seed_df[ordered_on] < seed_df[ordered_on].iloc[-1]]
+    ref_res = {
+        key: seed_df_trim.groupby(key_configs[key]["by"])
+        .agg(**key_configs[key]["agg"])
+        .reset_index()
+        for key in [key1, key2, key3]
+    } | {
+        key4: seed_df_trim.groupby(key_configs[key4]["bin_on"])
+        .agg(**key_configs[key4]["agg"])
+        .reset_index()
+    }
+    for key, ref_df in ref_res.items():
+        rec_res = store[key].pdf
+        assert rec_res.equals(ref_df)
+    # 1st append of new data.
+    start = seed_df[ordered_on].iloc[-1]
+    ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
+    seed_df2 = pDataFrame({ordered_on: ts, "val": rand_ints + 100, bin_on: bin_val + 10})
+    fp_write(
+        seed_path, seed_df2, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+    )
+    seed = ParquetFile(seed_path)
+    # Setup streamed aggregation.
+    streamagg(
+        seed=seed,
+        ordered_on=ordered_on,
+        store=store,
+        key=key_configs,
+        discard_last=True,
+        max_row_group_size=max_row_group_size,
+        reduction=reduction2,
+    )
+    # Test results
+    seed_df2_trim = seed_df2[seed_df2[ordered_on] < seed_df2[ordered_on].iloc[-1]]
+    ref_res = {
+        key: pconcat([seed_df, seed_df2_trim])
+        .groupby(key_configs[key]["by"])
+        .agg(**key_configs[key]["agg"])
+        .reset_index()
+        for key in [key1, key2, key3]
+    } | {
+        key4: pconcat([seed_df, seed_df2_trim])
+        .groupby(key_configs[key4]["bin_on"])
+        .agg(**key_configs[key4]["agg"])
+        .reset_index()
+    }
+    for key, ref_df in ref_res.items():
+        rec_res = store[key].pdf
+        assert rec_res.equals(ref_df)
+    # 2nd append of new data.
+    start = seed_df2[ordered_on].iloc[-1]
+    ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
+    seed_df3 = pDataFrame({ordered_on: ts, "val": rand_ints + 400, bin_on: bin_val + 40})
+    fp_write(
+        seed_path, seed_df3, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+    )
+    seed = ParquetFile(seed_path)
+    # Setup streamed aggregation.
+    streamagg(
+        seed=seed,
+        ordered_on=ordered_on,
+        store=store,
+        key=key_configs,
+        discard_last=True,
+        max_row_group_size=max_row_group_size,
+        reduction=reduction2,
+    )
+    # Test results
+    seed_df3_trim = seed_df3[seed_df3[ordered_on] < seed_df3[ordered_on].iloc[-1]]
+    ref_res = {
+        key: pconcat([seed_df, seed_df2, seed_df3_trim])
+        .groupby(key_configs[key]["by"])
+        .agg(**key_configs[key]["agg"])
+        .reset_index()
+        for key in [key1, key2, key3]
+    } | {
+        key4: pconcat([seed_df, seed_df2, seed_df3_trim])
+        .groupby(key_configs[key4]["bin_on"])
+        .agg(**key_configs[key4]["agg"])
+        .reset_index()
+    }
+    for key, ref_df in ref_res.items():
+        rec_res = store[key].pdf
+        assert rec_res.equals(ref_df)
 
 
 # Tester que 'bins' si reduction

--- a/tests/test_streamagg2.py
+++ b/tests/test_streamagg2.py
@@ -90,6 +90,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
         all_cols_in_res,
         trim_start,
         seed_index_restart_set,
+        reduction_bin_cols_res,
         reduction_seed_chunk_cols_res,
         reduction_agg_res,
         keys_config_res,
@@ -215,6 +216,7 @@ def test_setup_4_keys_with_default_parameters_for_writing(tmp_path):
     assert set(all_cols_in_res) == all_cols_in_ref
     assert not trim_start
     assert not seed_index_restart_set
+    assert not reduction_bin_cols_res
     assert not reduction_seed_chunk_cols_res
     assert not reduction_agg_res
 
@@ -277,6 +279,7 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
         all_cols_in_res,
         trim_start,
         seed_index_restart_set,
+        reduction_bin_cols_res,
         reduction_seed_chunk_cols_res,
         reduction_agg_res,
         keys_config_res,
@@ -386,6 +389,7 @@ def test_setup_4_keys_wo_default_parameters_for_writing_nor_post(tmp_path):
     assert set(all_cols_in_res) == all_cols_in_ref
     assert not trim_start
     assert not seed_index_restart_set
+    assert not reduction_bin_cols_res
     assert not reduction_seed_chunk_cols_res
     assert not reduction_agg_res
 
@@ -452,6 +456,7 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
         all_cols_in_res,
         trim_start,
         seed_index_restart_set,
+        reduction_bin_cols_res,
         reduction_seed_chunk_cols_res,
         reduction_agg_res,
         keys_config_res,
@@ -589,6 +594,13 @@ def test_setup_4_keys_with_default_parameters_for_writing_n_reduction(tmp_path):
     assert not seed_index_restart_set
     reduction_seed_chunk_cols_ref = {"in_dflt", "in_spec", bin_on_spec}
     assert set(reduction_seed_chunk_cols_res) == reduction_seed_chunk_cols_ref
+    reduction_bin_cols_ref = [
+        f"{REDUCTION_BIN_COL_PREFIX}0",
+        f"{REDUCTION_BIN_COL_PREFIX}1",
+        f"{REDUCTION_BIN_COL_PREFIX}2",
+        bin_on_spec,
+    ]
+    assert reduction_bin_cols_res == reduction_bin_cols_ref
 
 
 def test_setup_exception_no_bin_on_nor_by(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ Created on Wed Dec  1 18:35:00 2021.
 import zipfile
 from os import path as os_path
 
+import pytest
 from pandas import DataFrame
 from pandas import Grouper
 from pandas import Timestamp
@@ -65,7 +66,10 @@ def test_files_at_depth(tmp_path):
     assert paths_files == paths_ref
 
 
-def test_tcut():
+@pytest.mark.parametrize(
+    "closed,label", [("left", "left"), ("right", "left"), ("right", "right"), ("left", "right")]
+)
+def test_tcut(closed, label):
     # Test data
     ts = [
         Timestamp("2022/03/01 09:00"),
@@ -78,34 +82,7 @@ def test_tcut():
     df = DataFrame({"a": range(len(ts)), "ts": ts})
     # Test closed=left/label=left.
     grouper = Grouper(
-        key="ts", freq="2H", sort=False, origin="start_day", closed="left", label="left"
-    )
-    agg_ref = df.groupby(grouper)["a"].agg("first")
-    ddf = df.copy()
-    ddf["ts"] = tcut(df["ts"], grouper).astype("datetime64")
-    agg_res = ddf.groupby(grouper)["a"].agg("first")
-    assert agg_ref.equals(agg_res)
-    # Test closed=right/label=left.
-    grouper = Grouper(
-        key="ts", freq="2H", sort=False, origin="start_day", closed="right", label="left"
-    )
-    agg_ref = df.groupby(grouper)["a"].agg("first")
-    ddf = df.copy()
-    ddf["ts"] = tcut(df["ts"], grouper).astype("datetime64")
-    agg_res = ddf.groupby(grouper)["a"].agg("first")
-    assert agg_ref.equals(agg_res)
-    # Test closed=right/label=right.
-    grouper = Grouper(
-        key="ts", freq="2H", sort=False, origin="start_day", closed="right", label="right"
-    )
-    agg_ref = df.groupby(grouper)["a"].agg("first")
-    ddf = df.copy()
-    ddf["ts"] = tcut(df["ts"], grouper).astype("datetime64")
-    agg_res = ddf.groupby(grouper)["a"].agg("first")
-    assert agg_ref.equals(agg_res)
-    # Test closed=left/label=right.
-    grouper = Grouper(
-        key="ts", freq="2H", sort=False, origin="start_day", closed="left", label="right"
+        key="ts", freq="2H", sort=False, origin="start_day", closed=closed, label=label
     )
     agg_ref = df.groupby(grouper)["a"].agg("first")
     ddf = df.copy()


### PR DESCRIPTION
`streamagg` now able to handle several keys (i.e. several binning and aggregation definitions) to be conducted on the same seed data.
- `key` parameter can now be a dict to specify all binning/aggregation definitions,
- implementation of a reduction step (currently with pandas), that makes sense in case several binning/aggregations have to be conducted (perf improvement)
- preparing parallelization with joblib (WiP) (will be a next step)

Next steps include:
- reduction step with vaex as an option (perf improvement?)
- parallelization with joblib
