### PR TITLE
Binary md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
-
+  # Pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: forbid-new-submodules
       - id: fix-encoding-pragma
@@ -16,8 +16,8 @@ repos:
       - id: check-merge-conflict
       - id: check-symlinks
       - id: check-toml
-#      - id: check-yaml
 
+  # Codespell
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
@@ -25,12 +25,14 @@ repos:
         description: Checks for common misspellings.
         types_or: [python, rst, markdown]
 
+  # Pycln
   - repo: https://github.com/hadialqattan/pycln
     rev: v1.1.0
     hooks:
       - id: pycln
         name: pycln (Python unused imports)
 
+  # Black
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
@@ -39,6 +41,7 @@ repos:
             --line-length=100,
         ]
 
+  # Isort
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -55,8 +58,9 @@ repos:
             --use-parentheses,
         ]
 
+  # Flake8
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         name: flake8
@@ -90,6 +94,7 @@ repos:
                 oups/chainagg.py:C901
         ]
 
+  # Pydocstyle
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.1.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
 
   # Flake8
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.1.0
     hooks:
       - id: flake8
         name: flake8
@@ -96,7 +96,7 @@ repos:
 
   # Pydocstyle
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         files: ^oups/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,6 +102,9 @@ repos:
         files: ^oups/
         additional_dependencies:
           - toml
+        args: [
+          "--ignore=D200,D203,D212,D417",
+          ]
 
   - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: forbid-new-submodules
       - id: fix-encoding-pragma
@@ -19,22 +19,22 @@ repos:
 
   # Codespell
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.6
     hooks:
       - id: codespell
         description: Checks for common misspellings.
         types_or: [python, rst, markdown]
 
-  # Pycln
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v1.1.0
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v3.1.0
     hooks:
-      - id: pycln
-        name: pycln (Python unused imports)
+      - id: add-trailing-comma
+        name: add-trailing-comma
+        types: [python]
 
   # Black
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.10.1
     hooks:
       - id: black
         args: [
@@ -102,6 +102,27 @@ repos:
         files: ^oups/
         additional_dependencies:
           - toml
+
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [
+          "--black",
+          "--make-summary-multi-line",
+          "--pre-summary-newline",
+          "--blank",
+          "--recursive",
+          "--in-place",
+        ]
+
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v3.1.0
+    hooks:
+      - id: add-trailing-comma
+        name: add-trailing-comma
+        types: [python]
 
 # flake8 ignore justifications
 # ----------------------------

--- a/oups/__init__.py
+++ b/oups/__init__.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  1 18:35:00 2021.
 
 @author: yoh
+
 """
 from .chainagg import chainagg
 from .collection import ParquetSet

--- a/oups/chainagg.py
+++ b/oups/chainagg.py
@@ -3,6 +3,7 @@
 Created on Wed Mar  9 21:30:00 2022.
 
 @author: yoh
+
 """
 from copy import copy
 from dataclasses import dataclass
@@ -67,7 +68,8 @@ VAEX = "vaex"
 
 
 def _is_chainagg_result(handle: ParquetHandle) -> bool:
-    """Check if input handle is that of a dataset produced by streamaag.
+    """
+    Check if input handle is that of a dataset produced by streamaag.
 
     Parameters
     ----------
@@ -80,6 +82,7 @@ def _is_chainagg_result(handle: ParquetHandle) -> bool:
         `True` if parquet file contains metadata as produced by
         ``oups.chainagg``, which confirms this dataset has been produced with
         this latter function.
+
     """
     # As oups specific metadata is a string produced by json library, the last
     # 'in' condition is checking if the set of characters defined by
@@ -92,7 +95,8 @@ def _is_chainagg_result(handle: ParquetHandle) -> bool:
 
 
 def _get_chainagg_md(handle: ParquetHandle) -> tuple:
-    """Retrieve and deserialize chainagg metadata from previous aggregation.
+    """
+    Retrieve and deserialize chainagg metadata from previous aggregation.
 
     Parameters
     ----------
@@ -121,7 +125,8 @@ def _get_chainagg_md(handle: ParquetHandle) -> tuple:
     last_seed_index = read_json(StringIO(last_seed_index), **PANDAS_DESERIALIZE).iloc[0, 0]
     # 'last_agg_row' for stitching with new aggregation results.
     last_agg_row = read_json(
-        StringIO(chainagg_md[MD_KEY_LAST_AGGREGATION_ROW]), **PANDAS_DESERIALIZE
+        StringIO(chainagg_md[MD_KEY_LAST_AGGREGATION_ROW]),
+        **PANDAS_DESERIALIZE,
     )
     # Metadata related to binning process from past binnings on prior data.
     # It is used in case 'by' is a callable.
@@ -153,7 +158,8 @@ def _set_chainagg_md(
     binning_buffer: dict = None,
     post_buffer: dict = None,
 ):
-    """Serialize and record chainagg metadata from last aggregation and post.
+    """
+    Serialize and record chainagg metadata from last aggregation and post.
 
     Parameters
     ----------
@@ -170,12 +176,13 @@ def _set_chainagg_md(
     post_buffer : dict
         Last values from post-processing, that can be required when restarting
         post-processing of new aggregation results.
+
     """
     # Setup metadata for a future 'chainagg' execution.
     # Store a json serialized pandas series, to keep track of 'whatever the
     # object' the index is.
     last_seed_index = pDataFrame({MD_KEY_LAST_SEED_INDEX: [last_seed_index]}).to_json(
-        **PANDAS_SERIALIZE
+        **PANDAS_SERIALIZE,
     )
     last_agg_row = last_agg_row.to_json(**PANDAS_SERIALIZE)
     if binning_buffer:
@@ -189,7 +196,7 @@ def _set_chainagg_md(
             MD_KEY_BINNING_BUFFER: binning_buffer,
             MD_KEY_LAST_AGGREGATION_ROW: last_agg_row,
             MD_KEY_POST_BUFFER: post_buffer,
-        }
+        },
     }
     OUPS_METADATA[key] = metadata
 
@@ -205,7 +212,8 @@ def _post_n_write_agg_chunks(
     post_buffer: dict = None,
     other_metadata: tuple = None,
 ):
-    """Write list of aggregation row groups with optional post, then reset it.
+    """
+    Write list of aggregation row groups with optional post, then reset it.
 
     Parameters
     ----------
@@ -257,6 +265,7 @@ def _post_n_write_agg_chunks(
         If `None`, no metadata is recorded.
         If some metadata is defined, ``post_buffer`` also gets its way in
         metadata.
+
     """
     # Keep last row as there might be not further iteration.
     if len(chunks) > 1:
@@ -290,7 +299,8 @@ def _setup_binning(
     bin_on: Union[str, Tuple[str, str]] = None,
     reduction_bin_col: Union[str, None] = None,
 ):
-    """Specifically operate binning setup.
+    """
+    Specifically operate binning setup.
 
     Parameters
     ----------
@@ -410,7 +420,7 @@ def _setup_binning(
             raise ValueError(
                 "two different columns are defined for achieving binning,"
                 " both by `bin_on` and `by` parameters, pointing to"
-                f" '{bin_on}' and '{by.key}' columns respectively."
+                f" '{bin_on}' and '{by.key}' columns respectively.",
             )
         elif not bin_on and by.key:
             bin_on = by.key
@@ -461,7 +471,8 @@ def _setup(
     reduction: bool,
     **kwargs,
 ):
-    """Consolidate settings for parallel aggregations.
+    """
+    Consolidate settings for parallel aggregations.
 
     Parameters
     ----------
@@ -480,7 +491,7 @@ def _setup(
         Flag indicating if reduction step will be performed on seed chunk or
         not.
 
-    Other parameters
+    Other Parameters
     ----------------
     kwargs : dict
         Settings considered as default ones if not specified within ``keys``.
@@ -580,7 +591,11 @@ def _setup(
         bin_on = key_conf_in.pop("bin_on", None)
         by = key_conf_in.pop("by", None)
         (by, cols_to_by, bin_on, reduction_bin_col, bins, bin_out_col) = _setup_binning(
-            ordered_on=ordered_on, reduction=reduction, key_idx=i, by=by, bin_on=bin_on
+            ordered_on=ordered_on,
+            reduction=reduction,
+            key_idx=i,
+            by=by,
+            bin_on=bin_on,
         )
         # 'cols_to_by' defines columns to be loaded and sent to 'by' when 'by'
         # is a Callable. It has to be completed with 'ordered_on'.
@@ -604,7 +619,7 @@ def _setup(
             raise ValueError(
                 f"not possible to have {bin_out_col} as column name in"
                 " aggregated results as it is also for column containing group"
-                " keys."
+                " keys.",
             )
         # Step 1.2 / 'agg' and 'post'.
         # Initialize 'self_agg', 'agg' and update 'reduction_agg', 'all_cols_in'.
@@ -674,7 +689,7 @@ def _setup(
             if not _is_chainagg_result(prev_agg_res):
                 raise ValueError(f"provided key '{key}' is not that of 'chainagg' results.")
             seed_index_restart, last_agg_row, binning_buffer, post_buffer = _get_chainagg_md(
-                prev_agg_res
+                prev_agg_res,
             )
             seed_index_restart_set.add(seed_index_restart)
             # Comment: pandas does not care about index name for concat. If
@@ -745,7 +760,8 @@ def _iter_data(
     discard_last: bool,
     all_cols_in: List[str],
 ):
-    """Return an iterator over seed data.
+    """
+    Return an iterator over seed data.
 
     Parameters
     ----------
@@ -795,7 +811,9 @@ def _iter_data(
             filter_seed.append((ordered_on, "<", last_seed_index))
         if filter_seed:
             iter_data = seed.iter_row_groups(
-                filters=[filter_seed], row_filter=True, columns=all_cols_in
+                filters=[filter_seed],
+                row_filter=True,
+                columns=all_cols_in,
             )
         else:
             iter_data = seed.iter_row_groups(columns=all_cols_in)
@@ -848,7 +866,8 @@ def _post_n_bin(
     binning_buffer: dict,
     reduction_bin_col: str,
 ):
-    """Conduct post-processing, and writing for iter. n-1, and binning for iter. n.
+    """
+    Conduct post-processing, and writing for iter. n-1, and binning for iter. n.
 
     Parameters
     ----------
@@ -862,7 +881,7 @@ def _post_n_bin(
     key : str
         Key for retrieving metadata corresponding to aggregation results.
 
-    Other parameters
+    Other Parameters
     ----------------
     config
         Settings related to 'key' for conducting post-processing, writing and
@@ -914,7 +933,7 @@ def _post_n_bin(
             reduction_bins = by(data=seed_chunk.loc[:, cols_to_by], buffer=binning_buffer)
         elif isinstance(by, Grouper):
             reduction_bins = tcut(data=seed_chunk.loc[:, by.key], grouper=by).astype(
-                "datetime64[ns]"
+                "datetime64[ns]",
             )
         else:
             # Bin directly on existing column. Name is available with 'bins'.
@@ -978,7 +997,8 @@ def _group_n_stitch(
     self_agg: dict,
     isfbn: bool,
 ):
-    """Conduct groupby, and stitching of previous groupby with current one.
+    """
+    Conduct groupby, and stitching of previous groupby with current one.
 
     Parameters
     ----------
@@ -987,7 +1007,7 @@ def _group_n_stitch(
     key : str
         Key for recording aggregation results.
 
-    Other parameters
+    Other Parameters
     ----------------
     config
         Settings related to 'key' for conducting groupby and stitching.
@@ -1020,11 +1040,15 @@ def _group_n_stitch(
                 # columns. These bins are thus added here to maintain
                 # usual pandas behavior.
                 missing = date_range(
-                    start=last, end=first, freq=bins.freq, inclusive="neither", name=bins.key
+                    start=last,
+                    end=first,
+                    freq=bins.freq,
+                    inclusive="neither",
+                    name=bins.key,
                 )
                 if not missing.empty:
                     last_agg_row = pconcat(
-                        [last_agg_row, pDataFrame(index=missing, columns=last_agg_row.columns)]
+                        [last_agg_row, pDataFrame(index=missing, columns=last_agg_row.columns)],
                     )
                     n_added_rows = len(last_agg_row)
             # Add last previous row (and possibly missing ones if pandas
@@ -1057,7 +1081,9 @@ def _group_n_stitch(
 
 
 def agg_loop_wo_reduction(seed_chunk: pDataFrame, key: str, config: dict):
-    """Aggregate without reduction mechanism."""
+    """
+    Aggregate without reduction mechanism.
+    """
     _, updated_config = _post_n_bin(
         seed_chunk=seed_chunk,
         reduction=False,
@@ -1109,7 +1135,9 @@ def agg_loop_with_reduction(
     with_vaex: bool = False,
     vaex_sort: str = None,
 ):
-    """Aggregate with reduction mechanism."""
+    """
+    Aggregate with reduction mechanism.
+    """
     for seed_chunk in iter_data:
         bins_n_conf = p_job(
             delayed(_post_n_bin)(
@@ -1170,7 +1198,9 @@ def agg_loop_with_reduction(
         else:
             # Reduction with pandas.
             seed_chunk = pconcat(
-                [*reduction_bins, seed_chunk[reduction_seed_chunk_cols]], axis=1, copy=False
+                [*reduction_bins, seed_chunk[reduction_seed_chunk_cols]],
+                axis=1,
+                copy=False,
             )
             seed_chunk = seed_chunk.groupby(reduction_bin_cols, sort=False).agg(**reduction_agg)
             seed_chunk.reset_index(inplace=True)
@@ -1207,7 +1237,8 @@ def chainagg(
     parallel: bool = False,
     **kwargs,
 ):
-    """Aggregate sequentially on successive chunks (stream) of ordered data.
+    """
+    Aggregate sequentially on successive chunks (stream) of ordered data.
 
     This function conducts 'streamed aggregation' iteratively (out-of core)
     with optional post-processing of aggregation results (by use of vectorized
@@ -1338,7 +1369,7 @@ def chainagg(
         This does not impact execution of reduction in step in parallel if
         vaex is used.
 
-    Other parameters
+    Other Parameters
     ----------------
     kwargs : dict
         Settings forwarded to ``oups.writer.write`` when writing aggregation
@@ -1434,7 +1465,7 @@ def chainagg(
     if len(seed_index_restart_set) > 1:
         raise ValueError(
             "not possible to aggregate on multiple keys with existing"
-            " aggregation results not aggregated up to the same seed index."
+            " aggregation results not aggregated up to the same seed index.",
         )
     elif seed_index_restart_set:
         seed_index_restart = seed_index_restart_set.pop()
@@ -1442,7 +1473,12 @@ def chainagg(
         seed_index_restart = None
     # Initialize 'iter_data' generator from seed data, with correct trimming.
     last_seed_index, iter_data = _iter_data(
-        seed, ordered_on, trim_start, seed_index_restart, discard_last, all_cols_in
+        seed,
+        ordered_on,
+        trim_start,
+        seed_index_restart,
+        discard_last,
+        all_cols_in,
     )
     n_keys = len(keys)
     n_jobs = min(int(cpu_count() * 3 / 4), n_keys) if (parallel and n_keys > 1) else 1

--- a/oups/collection.py
+++ b/oups/collection.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  4 18:00:00 2021.
 
 @author: yoh
+
 """
 from dataclasses import dataclass
 from os import listdir
@@ -24,7 +25,8 @@ from oups.writer import write
 
 
 def is_parquet_file(file: str) -> bool:
-    """Assess extension to be that of a parquet file.
+    """
+    Assess extension to be that of a parquet file.
 
     Returns
     -------
@@ -32,6 +34,7 @@ def is_parquet_file(file: str) -> bool:
         `True` if file name is identified as a parquet file, i.e. ending with
         ``.parquet`` or ``.parq`` or being named ``_metadata`` or
         ``_common_metadata``.
+
     """
     return (
         file.endswith(".parquet")
@@ -42,7 +45,8 @@ def is_parquet_file(file: str) -> bool:
 
 
 def get_keys(basepath: str, indexer: Type[dataclass]) -> SortedSet:
-    """Identify directories containing a parquet dataset.
+    """
+    Identify directories containing a parquet dataset.
 
     Scan 'basepath' directory and create instances of 'indexer' class from
     compatible subpath.
@@ -65,6 +69,7 @@ def get_keys(basepath: str, indexer: Type[dataclass]) -> SortedSet:
         found in 'basepath' directory and with a 'valid' dataset (directory
         with files either ending with '.parq' or '.parquet' extension, or named
         '_medatada').
+
     """
     depth = indexer.depth
     paths_files = files_at_depth(basepath, depth)
@@ -78,13 +83,14 @@ def get_keys(basepath: str, indexer: Type[dataclass]) -> SortedSet:
                 any((is_parquet_file(file) for file in files))
                 and (key := indexer.from_path(DIR_SEP.join(path.rsplit(DIR_SEP, depth)[1:])))
             )
-        ]
+        ],
     )
     return keys
 
 
 class ParquetSet:
-    """Sorted list of keys (indexes to parquet datasets).
+    """
+    Sorted list of keys (indexes to parquet datasets).
 
     Attributes
     ----------
@@ -99,10 +105,12 @@ class ParquetSet:
     -----
     ``SortedSet`` is the data structure retained for ``keys`` instead of
     ``SortedList`` as its ``__contains__`` appears faster.
+
     """
 
     def __init__(self, basepath: str, indexer: Type[dataclass]):
-        """Instantiate parquet set.
+        """
+        Instantiate parquet set.
 
         Parameters
         ----------
@@ -113,6 +121,7 @@ class ParquetSet:
 
               - identifying existing parquet datasets in 'basepath' directory,
               - creating the folders where recording new parquet datasets.
+
         """
         if not is_toplevel(indexer):
             raise TypeError(f"{indexer.__name__} has to be '@toplevel' decorated.")
@@ -122,37 +131,52 @@ class ParquetSet:
 
     @property
     def basepath(self):
-        """Return basepath."""
+        """
+        Return basepath.
+        """
         return self._basepath
 
     @property
     def indexer(self):
-        """Return indexer."""
+        """
+        Return indexer.
+        """
         return self._indexer
 
     @property
     def keys(self):
-        """Return keys."""
+        """
+        Return keys.
+        """
         return self._keys
 
     def __len__(self):
-        """Return number of datasets."""
+        """
+        Return number of datasets.
+        """
         return len(self._keys)
 
     def __repr__(self):
-        """List of datasets."""
+        """
+        List of datasets.
+        """
         return "\n".join(map(str, self._keys))
 
     def __contains__(self, key):
-        """Assess presence of this dataset."""
+        """
+        Assess presence of this dataset.
+        """
         return key in self._keys
 
     def __iter__(self):
-        """Iterate over keys."""
+        """
+        Iterate over keys.
+        """
         yield from self._keys
 
     def set(self, key: dataclass, data: Union[pDataFrame, vDataFrame], **kwargs):
-        """Write 'data' to disk, at location defined by 'key'.
+        """
+        Write 'data' to disk, at location defined by 'key'.
 
         Parameters
         ----------
@@ -166,6 +190,7 @@ class ParquetSet:
         ----------------
         **kwargs : dict
             Keywords in 'kwargs' are forwarded to `writer.write`.
+
         """
         if not isinstance(key, self._indexer):
             raise TypeError(f"{key} is not an instance of {self._indexer.__name__}.")
@@ -183,7 +208,8 @@ class ParquetSet:
         key: dataclass,
         data: Union[Tuple[dict, Union[pDataFrame, vDataFrame]], Union[pDataFrame, vDataFrame]],
     ):
-        """Write ``data`` to disk, at location defined by ``key``.
+        """
+        Write ``data`` to disk, at location defined by ``key``.
 
         Parameters
         ----------
@@ -195,6 +221,7 @@ class ParquetSet:
             setting for `writer.write`, and second element is a dataframe
             (pandas or vaex).
             Or can be directly a dataframe (pandas or vaex).
+
         """
         if isinstance(data, tuple):
             kwargs, data = data
@@ -202,36 +229,42 @@ class ParquetSet:
                 raise TypeError(
                     f"first item {kwargs} should be a dict to "
                     "define parameter setting for "
-                    "'writer.write'."
+                    "'writer.write'.",
                 )
             self.set(key, data, **kwargs)
         else:
             self.set(key, data)
 
     def get(self, key: dataclass):
-        """Return `ParquetHandle`.
+        """
+        Return `ParquetHandle`.
 
         Parameter
         ---------
         key : dataclass
             Key specifying the location where to write the data. It has to be
             an instance of the dataclass provided at ParquetSet instantiation.
+
         """
         dirpath = os_path.join(self._basepath, key.to_path)
         return ParquetHandle(dirpath)
 
     def __getitem__(self, key: dataclass):
-        """Return the ``ParquetHandle`` instance corresponding to ``key``."""
+        """
+        Return the ``ParquetHandle`` instance corresponding to ``key``.
+        """
         return self.get(key)
 
     def __delitem__(self, key: dataclass):
-        """Remove dataset from parquet set.
+        """
+        Remove dataset from parquet set.
 
         Parameter
         ---------
         key : dataclass
             Key specifying the location where to write the data. It has to be
             an instance of the dataclass provided at ParquetSet instantiation.
+
         """
         if key in self._keys:
             # Keep track of intermediate partition folders, in case one get

--- a/oups/cumsegagg.py
+++ b/oups/cumsegagg.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  4 21:30:00 2021.
 
 @author: yoh
+
 """
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -40,9 +41,11 @@ KEY_LAST_CHUNK_RES = "last_chunk_res"
 
 
 def setup_cumsegagg(
-    agg: Dict[str, Tuple[str, str]], data_dtype: Dict[str, dtype]
+    agg: Dict[str, Tuple[str, str]],
+    data_dtype: Dict[str, dtype],
 ) -> Dict[dtype, Tuple[List[str], List[str], Tuple, int]]:
-    """Construct chaingrouby aggregation configuration.
+    """
+    Construct chaingrouby aggregation configuration.
 
     Parameters
     ----------
@@ -76,12 +79,13 @@ def setup_cumsegagg(
                                   in 'data', to which has to be applied the
                                   aggregation function.
                                 - a 2nd 1d numpy array with indices of columns
-                                  in 'res', to which are recoreded aggrgation
+                                  in 'res', to which are recoreded aggregation
                                   results
                    int64, 'n_cols'
                               Total number of columns in 'res' (summing for all
                               aggregation function).
            }``
+
     """
     cgb_agg_cfg = {}
     # Step 1.
@@ -145,7 +149,9 @@ def setup_cumsegagg(
 
 
 def setup_chunk_res(agg: Dict[dtype, tuple]) -> pDataFrame:
-    """Initialize one-row DataFrame for storing the first 'chunk_res'."""
+    """
+    Initialize one-row DataFrame for storing the first 'chunk_res'.
+    """
     chunk_res = {}
     for dtype_, (
         _,
@@ -155,7 +161,7 @@ def setup_chunk_res(agg: Dict[dtype, tuple]) -> pDataFrame:
     ) in agg.items():
         chunk_res_single_dtype = zeros(n_cols, dtype=dtype_)
         chunk_res.update(
-            {name: chunk_res_single_dtype[i : i + 1] for i, name in enumerate(cols_name_in_res)}
+            {name: chunk_res_single_dtype[i : i + 1] for i, name in enumerate(cols_name_in_res)},
         )
     return pDataFrame(chunk_res, copy=False)
 
@@ -170,7 +176,8 @@ def cumsegagg(
     snap_by: Optional[Union[TimeGrouper, Series, DatetimeIndex]] = None,
     error_on_0: Optional[bool] = True,
 ) -> Union[pDataFrame, Tuple[pDataFrame, pDataFrame]]:
-    """Cumulative segmented aggregations, with optional snapshotting.
+    """
+    Cumulative segmented aggregations, with optional snapshotting.
 
     In this function, "snapshotting" is understood as the action of making
     isolated observations. When using snapshots, values derived from
@@ -288,7 +295,7 @@ def cumsegagg(
     ``False`` when reaching the end of input data.
     This is a limitation. It should be ``False`` only to mark the actual end of
     the bins. As a result, this internal flag 'preserve_res' cannot be output
-    for re-use in a next restart step.
+    for reuse in a next restart step.
     An option to circumvent this is to use snapshots instead of bins as media
     to output aggregation results for last, in-progress bin.
     This option has not been implemented.
@@ -352,7 +359,7 @@ def cumsegagg(
 
       - **cumulative segmented aggregation ('cumsegagg()')**
         -1 'preserve_res' parameter is used to indicate if aggregation
-           calculations start from scratch (first iteration) or re-use past
+           calculations start from scratch (first iteration) or reuse past
            aggregation results (following iterations).
            Aggregation results from last, in-progress bin can then be
            forwarded.
@@ -433,18 +440,18 @@ def cumsegagg(
             chunk_res_prev.loc[:, cols_name_in_res].to_numpy(copy=False).reshape(n_cols)
         )
         chunk_res.update(
-            {name: chunk_res_single_dtype[i : i + 1] for i, name in enumerate(cols_name_in_res)}
+            {name: chunk_res_single_dtype[i : i + 1] for i, name in enumerate(cols_name_in_res)},
         )
         # Setup 'bin_res_single_dtype'.
         bin_res_single_dtype = zeros((n_bins, n_cols), dtype=dtype_)
         bin_res.update(
-            {name: bin_res_single_dtype[:, i] for i, name in enumerate(cols_name_in_res)}
+            {name: bin_res_single_dtype[:, i] for i, name in enumerate(cols_name_in_res)},
         )
         # Setup 'snap_res_single_dtype'.
         if snap_by is not None:
             snap_res_single_dtype = zeros((n_snaps, n_cols), dtype=dtype_)
             snap_res.update(
-                {name: snap_res_single_dtype[:, i] for i, name in enumerate(cols_name_in_res)}
+                {name: snap_res_single_dtype[:, i] for i, name in enumerate(cols_name_in_res)},
             )
         if dtype_ == DTYPE_DATETIME64:
             data_single_dtype = data_single_dtype.view(DTYPE_INT64)
@@ -486,7 +493,7 @@ def cumsegagg(
                 # As of pandas 1.5.3, use "Int64" dtype to work with nullable 'int'.
                 # (it is a pandas dtype, not a numpy one)
                 bin_res[agg[DTYPE_INT64][1]] = bin_res[agg[DTYPE_INT64][1]].astype(
-                    DTYPE_NULLABLE_INT64
+                    DTYPE_NULLABLE_INT64,
                 )
             for dtype_, (
                 _,
@@ -510,7 +517,7 @@ def cumsegagg(
                     # As of pandas 1.5.3, use "Int64" dtype to work with nullable 'int'.
                     # (it is a pandas dtype, not a numpy one)
                     snap_res[agg[DTYPE_INT64][1]] = snap_res[agg[DTYPE_INT64][1]].astype(
-                        DTYPE_NULLABLE_INT64
+                        DTYPE_NULLABLE_INT64,
                     )
                 for dtype_, (
                     _,
@@ -522,11 +529,11 @@ def cumsegagg(
     if error_on_0:
         if snap_by is not None and snap_res.eq(0).any().any():
             raise ValueError(
-                "at least one null value exists in 'snap_res' which is likely to hint a bug."
+                "at least one null value exists in 'snap_res' which is likely to hint a bug.",
             )
         if bin_res.eq(0).any().any():
             raise ValueError(
-                "at least one null value exists in 'bin_res' which is likely to hint a bug."
+                "at least one null value exists in 'bin_res' which is likely to hint a bug.",
             )
     if snap_by is not None:
         return bin_res, snap_res

--- a/oups/defines.py
+++ b/oups/defines.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  1 18:35:00 2021.
 
 @author: yoh
+
 """
 from os import path as os_path
 

--- a/oups/indexer.py
+++ b/oups/indexer.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  1 18:35:00 2021.
 
 @author: yoh
+
 """
 import re
 from dataclasses import dataclass
@@ -37,7 +38,8 @@ def _dataclass_instance_to_dict(obj: dataclass) -> dict:
 
 
 def _dataclass_instance_to_lists(obj: dataclass) -> Iterator[List[Any]]:
-    """Yield items as lists of fields values.
+    """
+    Yield items as lists of fields values.
 
     If a new dataclass instance is the last field, its fields values are
     yielded as next item, and so on...
@@ -51,6 +53,7 @@ def _dataclass_instance_to_lists(obj: dataclass) -> Iterator[List[Any]]:
     -------
     Iterator[List[Any]]
         Yields list of fields values.
+
     """
     fields = list(_dataclass_instance_to_dict(obj).values())
     if fields:
@@ -60,7 +63,8 @@ def _dataclass_instance_to_lists(obj: dataclass) -> Iterator[List[Any]]:
 
 
 def _validate_toplevel_instance(toplevel: dataclass):
-    """Validate a 'toplevel'-decorated data class instance.
+    """
+    Validate a 'toplevel'-decorated data class instance.
 
     Check field type is only among 'int', 'str' or another dataclass instance.
     Check that there is at most only one dataclass instance per nesting level,
@@ -70,6 +74,7 @@ def _validate_toplevel_instance(toplevel: dataclass):
     Parameters
     ----------
     toplevel : dataclass
+
     """
     forbidden_chars = (toplevel.fields_sep, *FORBIDDEN_CHARS)
     for fields_ in _dataclass_instance_to_lists(toplevel):
@@ -84,13 +89,13 @@ def _validate_toplevel_instance(toplevel: dataclass):
                     # 1st position.
                     raise TypeError(
                         "a dataclass instance cannot be the only \
-field of a level."
+field of a level.",
                     )
                 if counter + 1 != number_of_fields:
                     # A dataclass instance cannot be in last position.
                     raise TypeError(
                         "a dataclass instance is only possible in \
-last position."
+last position.",
                     )
             else:
                 # If not a dataclass instance.
@@ -98,7 +103,7 @@ last position."
                 if any((symb in field_as_str for symb in forbidden_chars)):
                     raise ValueError(
                         f"use of a forbidden character among \
-{forbidden_chars} is not possible in {field_as_str}."
+{forbidden_chars} is not possible in {field_as_str}.",
                     )
             if not ((type(field) in TYPE_ACCEPTED) or _is_dataclass_instance(field)):
                 raise TypeError(f"field type {type(field)} not possible.")
@@ -106,7 +111,8 @@ last position."
 
 
 def _dataclass_instance_to_str(toplevel: dataclass, as_path: bool = False) -> str:
-    """Return a dataclass instance as a string.
+    """
+    Return a dataclass instance as a string.
 
     The different levels in this string are either separated with 'fields_sep'
     or with DIR_SEP.
@@ -126,6 +132,7 @@ def _dataclass_instance_to_str(toplevel: dataclass, as_path: bool = False) -> st
             - At a same level, using 'fields_sep';
             - Between different levels, either 'fields_sep', either DIR_SEP,
               depending 'as_path'.
+
     """
     levels_sep = DIR_SEP if as_path else toplevel.fields_sep
     to_str = []
@@ -140,7 +147,8 @@ def _dataclass_instance_to_str(toplevel: dataclass, as_path: bool = False) -> st
 
 
 def _dataclass_fields_types_to_lists(cls: Type[dataclass]) -> List[List[Any]]:
-    """Type of fields in dataclass returned in lists.
+    """
+    Type of fields in dataclass returned in lists.
 
     Return the type of each field, one list per level, and all levels in a
     list.
@@ -154,6 +162,7 @@ def _dataclass_fields_types_to_lists(cls: Type[dataclass]) -> List[List[Any]]:
     -------
     List[List[Any]]
         List of fields types lists, one list per level.
+
     """
     types = [[field.type for field in fields(cls)]]
     while is_dataclass(last := types[-1][-1]):
@@ -162,7 +171,8 @@ def _dataclass_fields_types_to_lists(cls: Type[dataclass]) -> List[List[Any]]:
 
 
 def _dataclass_instance_from_str(cls: Type[dataclass], string: str) -> Union[dataclass, None]:
-    """Return a dataclass instance derived from input string.
+    """
+    Return a dataclass instance derived from input string.
 
     Level separator can either be DIR_SEP or 'cls.fields_sep'.
     If dataclass '__init__' fails, `None` is returned.
@@ -179,6 +189,7 @@ def _dataclass_instance_from_str(cls: Type[dataclass], string: str) -> Union[dat
     -------
     Union[dataclass, None]
         Dataclass instance derived from input string.
+
     """
     types = _dataclass_fields_types_to_lists(cls)
     # Split string depending 'fields_sep' and 'DIR_SEP', into different fields.
@@ -201,7 +212,8 @@ def _dataclass_instance_from_str(cls: Type[dataclass], string: str) -> Union[dat
             level = [
                 field_type(field_as_string)
                 for field_type, field_as_string in zip(
-                    level_types[:-1], strings_as_list[-level_length:]
+                    level_types[:-1],
+                    strings_as_list[-level_length:],
                 )
             ] + [level_types[-1](*level)]
         return cls(*level, check=False)
@@ -215,9 +227,11 @@ def _dataclass_instance_from_str(cls: Type[dataclass], string: str) -> Union[dat
 
 
 def _get_depth(obj: Union[dataclass, Type[dataclass]]) -> int:
-    """Return number of levels, including 'toplevel'.
+    """
+    Return number of levels, including 'toplevel'.
 
     To be decorated with '@property'.
+
     """
     depth = 1
     level = obj
@@ -227,21 +241,28 @@ def _get_depth(obj: Union[dataclass, Type[dataclass]]) -> int:
 
 
 class TopLevel(type):
-    """Metaclass defining class properties of '@toplevel'-decorated class."""
+    """
+    Metaclass defining class properties of '@toplevel'-decorated class.
+    """
 
     @property
     def fields_sep(cls) -> str:
-        """Return field separator."""
+        """
+        Return field separator.
+        """
         return cls._fields_sep
 
     @property
     def depth(cls) -> int:
-        """Return depth, i.e. number of levels."""
+        """
+        Return depth, i.e. number of levels.
+        """
         return cls._depth
 
 
 def toplevel(index_class=None, *, fields_sep: str = DEFAULT_FIELDS_SEP):
-    """Turn decorated class into an indexing schema.
+    """
+    Turn decorated class into an indexing schema.
 
     Decorated class is equipped with methods and attributes to use with a
     ``ParquetSet`` instance.
@@ -278,6 +299,7 @@ def toplevel(index_class=None, *, fields_sep: str = DEFAULT_FIELDS_SEP):
         object coming in last position;
       - Value of attribute can not incorporate forbidden characters like ``/``
         and ``self.fields_sep``.
+
     """
 
     def tweak(index_class):
@@ -332,23 +354,26 @@ def toplevel(index_class=None, *, fields_sep: str = DEFAULT_FIELDS_SEP):
 
 
 def is_toplevel(toplevel) -> bool:
-    """Return `True` if `toplevel`-decorated class.
+    """
+    Return `True` if `toplevel`-decorated class.
 
     Returns 'True' if 'toplevel' (class or instance) has been decorated with
-    '@toplevel'. It checks presence 'fields_sep' attribute and 'from_path'
-    method.
+    '@toplevel'. It checks presence 'fields_sep' attribute and 'from_path' method.
+
     """
     return hasattr(toplevel, "fields_sep") and callable(getattr(toplevel, "from_path", None))
 
 
 def sublevel(index_class):
-    """Define a subdirectory level.
+    """
+    Define a subdirectory level.
 
     This decorator really is an alias of ``@dataclass`` decorator, with
     parameters set to:
 
         - ``order=True``,
         - ``frozen=True``
+
     """
     # Wrap with `@dataclass`.
     # TODO

--- a/oups/jcumsegagg.py
+++ b/oups/jcumsegagg.py
@@ -3,6 +3,7 @@
 Created on Fri Dec 22 19:00:00 2022.
 
 @author: yoh
+
 """
 from typing import Callable, Tuple
 
@@ -21,7 +22,8 @@ from numpy import zeros
     cache=True,
 )
 def jfirst(ar: ndarray, initial: ndarray, use_init: bool):
-    """Jitted first.
+    """
+    Jitted first.
 
     Parameters
     ----------
@@ -37,6 +39,7 @@ def jfirst(ar: ndarray, initial: ndarray, use_init: bool):
     -------
     np.ndarray
         First in 'ar' if 'use_init' is false, else 'initial'.
+
     """
     if use_init > 0:
         return initial
@@ -51,7 +54,8 @@ def jfirst(ar: ndarray, initial: ndarray, use_init: bool):
     cache=True,
 )
 def jlast(ar: ndarray, initial: ndarray, use_init: bool):
-    """Jitted last.
+    """
+    Jitted last.
 
     Parameters
     ----------
@@ -68,6 +72,7 @@ def jlast(ar: ndarray, initial: ndarray, use_init: bool):
     -------
     np.ndarray
         Last in 'ar' if 'ar' is not a null array, else 'initial'.
+
     """
     if len(ar) > 0:
         return ar[-1]
@@ -83,7 +88,8 @@ def jlast(ar: ndarray, initial: ndarray, use_init: bool):
     parallel=True,
 )
 def jmax(ar: ndarray, initial: ndarray, use_init: bool):
-    """Jitted max.
+    """
+    Jitted max.
 
     Parameters
     ----------
@@ -100,6 +106,7 @@ def jmax(ar: ndarray, initial: ndarray, use_init: bool):
     np.ndarray
         Max values per column in 'ar', including 'initial' if 'use_init' is
         true.
+
     """
     len_ar = len(ar)
     if len_ar > 0:
@@ -127,7 +134,8 @@ def jmax(ar: ndarray, initial: ndarray, use_init: bool):
     parallel=True,
 )
 def jmin(ar: ndarray, initial: ndarray, use_init: bool):
-    """Jitted min.
+    """
+    Jitted min.
 
     Parameters
     ----------
@@ -144,6 +152,7 @@ def jmin(ar: ndarray, initial: ndarray, use_init: bool):
     np.ndarray
         Min values per column in 'ar', including 'initial' if 'use_init' is
         true.
+
     """
     len_ar = len(ar)
     if len_ar > 0:
@@ -171,7 +180,8 @@ def jmin(ar: ndarray, initial: ndarray, use_init: bool):
     parallel=True,
 )
 def jsum(ar: ndarray, initial: ndarray, use_init: bool):
-    """Jitted sum.
+    """
+    Jitted sum.
 
     Parameters
     ----------
@@ -188,6 +198,7 @@ def jsum(ar: ndarray, initial: ndarray, use_init: bool):
     np.ndarray
         Sum of values per column in 'ar', including 'initial' if 'use_init' is
         true.
+
     """
     len_ar = len(ar)
     if len_ar > 0:
@@ -229,7 +240,8 @@ def jcsagg(
     null_bin_indices: ndarray,  # 1d
     null_snap_indices: ndarray,  # 1d
 ):
-    """Group assuming contiguity.
+    """
+    Group assuming contiguity.
 
     Parameters
     ----------
@@ -241,7 +253,7 @@ def jcsagg(
           - for related aggregation function, a 1d numpy array listing the
             indices of columns in 'data' to which apply the aggregation
             function.
-          - for related aggregration function, and corresponding column in
+          - for related aggregation function, and corresponding column in
             'data', the index of the column in 'bin_res' and/or 'snap_res' to
             which recording the result. These indices are listed in a 1d numpy
             array, sorted in the same order than indices of columns in 'data'.
@@ -296,6 +308,7 @@ def jcsagg(
     iteration.
     But if last bin from previous iteration has been empty, then 'chunk_res'
     does not contain relevant results to be forwarded.
+
     """
     # 'pinnu' is 'prev_is_non_null_update'. It is renamed 'preserve_res'.
     # With 'preserve_res' True, then cumulate (pass-through) previous results.
@@ -374,7 +387,9 @@ def jcsagg(
                 for agg in literal_unroll(aggs):
                     agg_func, cols_data, cols_res = agg
                     chunk_res[cols_res] = agg_func(
-                        chunk[:, cols_data], chunk_res[cols_res], preserve_res
+                        chunk[:, cols_data],
+                        chunk_res[cols_res],
+                        preserve_res,
                     )
             # Step 2: record results.
             if is_update:

--- a/oups/router.py
+++ b/oups/router.py
@@ -4,10 +4,10 @@ Created on Wed Dec 26 22:30:00 2021.
 
 @author: yoh
 """
-import json
 from functools import cached_property
 from os import scandir
 
+from cloudpickle import loads
 from fastparquet import ParquetFile
 from vaex import open_many
 
@@ -96,6 +96,6 @@ class ParquetHandle:
         """Return specific oups metadata."""
         md = self.pf.key_value_metadata
         if OUPS_METADATA_KEY in md:
-            return json.loads(md[OUPS_METADATA_KEY])
+            return loads(md[OUPS_METADATA_KEY])
         else:
             return None

--- a/oups/router.py
+++ b/oups/router.py
@@ -3,6 +3,7 @@
 Created on Wed Dec 26 22:30:00 2021.
 
 @author: yoh
+
 """
 from functools import cached_property
 from os import scandir
@@ -16,7 +17,8 @@ from oups.writer import OUPS_METADATA_KEY
 
 
 class ParquetHandle:
-    """Handle to parquet dataset and statistics on disk.
+    """
+    Handle to parquet dataset and statistics on disk.
 
     Attributes
     ----------
@@ -33,36 +35,47 @@ class ParquetHandle:
     -------
     min_max(col)
         Retrieve min and max from statistics for a column.
+
     """
 
     def __init__(self, dirpath: str):
-        """Instantiate parquet handle.
+        """
+        Instantiate parquet handle.
 
         Parameter
         ---------
         dirpath : str
             Directory path from where to load data.
+
         """
         self._dirpath = dirpath
 
     @property
     def dirpath(self):
-        """Return dirpath."""
+        """
+        Return dirpath.
+        """
         return self._dirpath
 
     @cached_property
     def pf(self):
-        """Return handle to data through a parquet file."""
+        """
+        Return handle to data through a parquet file.
+        """
         return ParquetFile(self._dirpath)
 
     @property
     def pdf(self):
-        """Return data as a pandas dataframe."""
+        """
+        Return data as a pandas dataframe.
+        """
         return ParquetFile(self._dirpath).to_pandas()
 
     @property
     def vdf(self):
-        """Return handle to data through a vaex dataframe."""
+        """
+        Return handle to data through a vaex dataframe.
+        """
         # To circumvent vaex lexicographic filename sorting to order row
         # groups, ordering the list of files is required.
         files = [file.name for file in scandir(self._dirpath) if file.name[-7:] == "parquet"]
@@ -71,7 +84,8 @@ class ParquetHandle:
         return open_many(map(prefix_dirpath, files))
 
     def min_max(self, col: str) -> tuple:
-        """Return min and max of values of a column.
+        """
+        Return min and max of values of a column.
 
         Parameters
         ----------
@@ -82,18 +96,23 @@ class ParquetHandle:
         -------
         tuple
             Min and max values of column.
+
         """
         pf_stats = ParquetFile(self._dirpath).statistics
         return (min(pf_stats["min"][col]), max(pf_stats["max"][col]))
 
     @property
     def metadata(self) -> dict:
-        """Return metadata stored when using `oups.writer.write()`."""
+        """
+        Return metadata stored when using `oups.writer.write()`.
+        """
         return self.pf.key_value_metadata
 
     @property
     def _oups_metadata(self) -> dict:
-        """Return specific oups metadata."""
+        """
+        Return specific oups metadata.
+        """
         md = self.pf.key_value_metadata
         if OUPS_METADATA_KEY in md:
             return loads(md[OUPS_METADATA_KEY])

--- a/oups/segmentby.py
+++ b/oups/segmentby.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  4 21:30:00 2021.
 
 @author: yoh
+
 """
 from functools import partial
 from math import ceil
@@ -63,7 +64,8 @@ def _next_chunk_starts(
     right_edges: ndarray,
     right: bool,
 ):
-    """Return row indices for starts of next chunks.
+    """
+    Return row indices for starts of next chunks.
 
     Parameters
     ----------
@@ -90,6 +92,7 @@ def _next_chunk_starts(
         null chunks identified.
     data_traversed : boolean
         Specifies if 'data' has been completely traversed or not.
+
     """
     # Output variables
     next_chunk_starts = zeros(len(right_edges), dtype=DTYPE_INT64)
@@ -140,7 +143,8 @@ def by_scale(
     closed: Optional[str] = None,
     buffer: Optional[dict] = None,
 ) -> Tuple[ndarray, Series, int, str, Series, bool]:
-    """Segment an ordered DatetimeIndex or Series.
+    """
+    Segment an ordered DatetimeIndex or Series.
 
     Parameters
     ----------
@@ -222,7 +226,7 @@ def by_scale(
             chunk_labels, chunk_ends = by
             if len(chunk_labels) != len(chunk_ends):
                 raise ValueError(
-                    "number of chunk labels has to be " "equal to number of chunk ends."
+                    "number of chunk labels has to be " "equal to number of chunk ends.",
                 )
         else:
             chunk_labels = chunk_ends = by
@@ -239,7 +243,7 @@ def by_scale(
                 if buffer[KEY_RESTART_KEY] != chunk_ends[0]:
                     raise ValueError(
                         f"'by' needs to contain value {buffer[KEY_RESTART_KEY]} "
-                        "to restart correctly."
+                        "to restart correctly.",
                     )
                 n_first_chunks_to_remove = n_chunk_ends_init - len(chunk_ends)
                 chunk_labels = chunk_labels[n_first_chunks_to_remove:]
@@ -272,7 +276,7 @@ def by_scale(
                 ):
                     raise ValueError(
                         "2nd chunk end in 'by' has to be larger than value "
-                        f"{buffer[KEY_LAST_ON_VALUE]} to restart correctly."
+                        f"{buffer[KEY_LAST_ON_VALUE]} to restart correctly.",
                     )
                 if (closed == RIGHT and chunk_ends[0] < last_on_value) or (
                     closed == LEFT and chunk_ends[0] <= last_on_value
@@ -299,7 +303,9 @@ def by_scale(
         )
     else:
         next_chunk_starts, n_null_chunks, data_traversed = _next_chunk_starts(
-            on.to_numpy(copy=False), chunk_ends.to_numpy(copy=False), closed == RIGHT
+            on.to_numpy(copy=False),
+            chunk_ends.to_numpy(copy=False),
+            closed == RIGHT,
         )
     n_chunks = len(next_chunk_starts)
     # Rationale for selecting the "restart key".
@@ -366,7 +372,8 @@ def by_x_rows(
     closed: Optional[str] = LEFT,
     buffer: Optional[dict] = None,
 ) -> Tuple[ndarray, Series, int, str, Series, bool]:
-    """Segment by group of x rows.
+    """
+    Segment by group of x rows.
 
     Dummy binning function for testing 'cumsegagg' with 'bin_by' set as a
     Callable.
@@ -443,7 +450,9 @@ def by_x_rows(
     # Define 'next_chunk_starts'.
     first_next_chunk_start = rows_in_continued_bin if rows_in_continued_bin else min(by, len_on)
     next_chunk_starts = arange(
-        start=first_next_chunk_start, stop=(n_bins - 1) * by + first_next_chunk_start + 1, step=by
+        start=first_next_chunk_start,
+        stop=(n_bins - 1) * by + first_next_chunk_start + 1,
+        step=by,
     )
     # Make a copy and arrange for deriving 'chunk_starts', required for
     # defining bin labels. 'bin_labels' are derived from last column (is then
@@ -487,7 +496,7 @@ def by_x_rows(
                 # If a new bin has been created right at start,
                 # insert an empty one with label of last bin at prev iteration.
                 bin_labels = pconcat(
-                    [Series([buffer[KEY_LAST_BIN_LABEL]]), bin_labels]
+                    [Series([buffer[KEY_LAST_BIN_LABEL]]), bin_labels],
                 ).reset_index(drop=True)
                 first_bin_end = buffer[KEY_LAST_BIN_END] if closed == RIGHT else on.iloc[0]
                 bin_ends = pconcat([Series([first_bin_end]), bin_ends]).reset_index(drop=True)
@@ -514,7 +523,8 @@ def mergesort(
     keys: Tuple[ndarray, ndarray],
     force_last_from_second: Optional[bool] = False,
 ) -> Tuple[ndarray, ndarray]:
-    """Mergesort labels from keys.
+    """
+    Mergesort labels from keys.
 
     Parameters
     ----------
@@ -541,6 +551,7 @@ def mergesort(
     If a value is found in both input arrays, then value of 2nd input array
     comes after value of 1st input array, as can be checked with insertion
     indices.
+
     """
     # TODO: transition this to numba.
     labels1, labels2 = labels
@@ -549,11 +560,11 @@ def mergesort(
     len_labels2 = len(labels2)
     if len(keys1) != len_labels1:
         raise ValueError(
-            "not possible to have arrays of different length for first labels and keys arrays."
+            "not possible to have arrays of different length for first labels and keys arrays.",
         )
     if len(keys2) != len_labels2:
         raise ValueError(
-            "not possible to have arrays of different length for second labels and keys arrays."
+            "not possible to have arrays of different length for second labels and keys arrays.",
         )
     if force_last_from_second:
         len_tot = len_labels1 + len_labels2
@@ -570,7 +581,8 @@ def setup_segmentby(
     ordered_on: Optional[str] = None,
     snap_by: Optional[Union[TimeGrouper, Series]] = None,
 ) -> Dict[str, Union[Callable, str]]:
-    """Check and setup parameters to operate data segmentation.
+    """
+    Check and setup parameters to operate data segmentation.
 
     Parameters
     ----------
@@ -604,7 +616,7 @@ def setup_segmentby(
             if bin_on:
                 if bin_by.key != bin_on:
                     raise ValueError(
-                        "not possible to set 'bin_by.key' and 'bin_on' to different values."
+                        "not possible to set 'bin_by.key' and 'bin_on' to different values.",
                     )
             else:
                 bin_on = bin_by.key
@@ -612,7 +624,7 @@ def setup_segmentby(
             raise ValueError("not possible to set both 'bin_by.key' and 'bin_on' to `None`.")
         if ordered_on and ordered_on != bin_on:
             raise ValueError(
-                "not possible to set 'bin_on' and 'ordered_on' to different values when 'bin_by' is a TimeGrouper."
+                "not possible to set 'bin_on' and 'ordered_on' to different values when 'bin_by' is a TimeGrouper.",
             )
         elif not ordered_on:
             # Case 'ordered_on' has not been provided but 'bin_on' has been.
@@ -631,16 +643,16 @@ def setup_segmentby(
                     ordered_on = snap_by.key
                 elif snap_by.key != ordered_on:
                     raise ValueError(
-                        "not possible to set 'ordered_on' and 'snap_by.key' to different values."
+                        "not possible to set 'ordered_on' and 'snap_by.key' to different values.",
                     )
             if bin_by_closed and snap_by.closed != bin_by_closed:
                 raise ValueError(
-                    "not possible to set 'bin_by.closed' and 'snap_by.closed' to different values."
+                    "not possible to set 'bin_by.closed' and 'snap_by.closed' to different values.",
                 )
         elif not ordered_on:
             # Case 'snap_by' is not a TimeGrouper.
             raise ValueError(
-                "not possible to leave 'ordered_on' to `None` in case of snapshotting."
+                "not possible to leave 'ordered_on' to `None` in case of snapshotting.",
             )
     return {
         BIN_BY: bin_by,
@@ -655,7 +667,8 @@ def setup_segmentby(
 
 
 def setup_mainbuffer(buffer: dict, with_snapshot: Optional[bool] = False) -> Tuple[dict, dict]:
-    """Return 'buffer_bin' and 'buffer_snap' from main buffer.
+    """
+    Return 'buffer_bin' and 'buffer_snap' from main buffer.
 
     Parameters
     ----------
@@ -671,6 +684,7 @@ def setup_mainbuffer(buffer: dict, with_snapshot: Optional[bool] = False) -> Tup
     Tuple[dict, dict]
         The first dict is the binning buffer.
         The second dict is the snapshotting buffer.
+
     """
     if buffer is not None:
         if with_snapshot:
@@ -694,7 +708,8 @@ def segmentby(
     snap_by: Optional[Union[TimeGrouper, IntervalIndex]] = None,
     buffer: Optional[dict] = None,
 ) -> Tuple[ndarray, ndarray, Series, int, Series, int]:
-    """Identify starts of segments in data, either bins or optionally snapshots.
+    """
+    Identify starts of segments in data, either bins or optionally snapshots.
 
     Parameters
     ----------
@@ -848,6 +863,7 @@ def segmentby(
     "on-going" bin is made. In case of snapshot(s) positioned exactly on
     segment(s) ends, at the same row index in data, the observation point will
     always come before the bin end.
+
     """
     # TODO : split 'by_scale' into 'by_pgrouper' and 'by_scale'.
     # TODO : make some tests validating use of 'by_scale' as 'bin_by' parameter.
@@ -877,7 +893,7 @@ def segmentby(
         ):
             raise ValueError(
                 f"column '{ordered_on}' is not ordered. It has to be for "
-                "'cumsegagg' to operate faultlessly."
+                "'cumsegagg' to operate faultlessly.",
             )
     on = data.loc[:, bin_by[ON_COLS]]
     # 'bin_by' binning.
@@ -905,7 +921,7 @@ def segmentby(
         raise ValueError(
             "series of bins have to cover the full length of 'data'. "
             f"But last bin ends at row {next_chunk_starts[-1]} "
-            f"excluded, while size of data is {len(data)}."
+            f"excluded, while size of data is {len(data)}.",
         )
     if n_bins > 1 and buffer is not None and next_chunk_starts[-2] == len(on):
         # In case a user-provided 'bin_by()' Callable is used, check if there
@@ -915,7 +931,7 @@ def segmentby(
         raise ValueError(
             "there is at least one empty trailing bin. "
             "This is not possible if planning to restart on new "
-            "data in a next iteration."
+            "data in a next iteration.",
         )
     if snap_by is not None:
         if buffer is not None:
@@ -926,14 +942,17 @@ def segmentby(
                 raise ValueError(
                     f"not possible to have label '{buffer[KEY_LAST_BIN_LABEL]}' "
                     "of last bin at previous iteration different than label "
-                    f"'{bin_labels[0]}' of first bin at current itation."
+                    f"'{bin_labels[0]}' of first bin at current itation.",
                 )
             # Weird way to get last element because 'bin_labels' is not
             # necessarily a Series for which 'iloc' should be used.
             buffer[KEY_LAST_BIN_LABEL] = bin_labels[n_bins - 1]
         # Define points of observation
         (next_snap_starts, snap_labels, n_max_null_snaps, _, snap_ends, _) = by_scale(
-            on=data.loc[:, ordered_on], by=snap_by, closed=bin_closed, buffer=buffer_snap
+            on=data.loc[:, ordered_on],
+            by=snap_by,
+            closed=bin_closed,
+            buffer=buffer_snap,
         )
         # Consolidate 'next_snap_starts' into 'next_chunk_starts'.
         # If bins are left-closed, the end of the last bin can possibly be
@@ -972,8 +991,8 @@ def segmentby(
                     next_chunk_starts[indices_of_bins_followed_by_a_snap]
                     - next_chunk_starts[indices_of_bins_followed_by_a_snap + 1]
                 )
-                == 0
-            )[0]
+                == 0,
+            )[0],
         )
     else:
         bin_indices = NULL_INT64_1D_ARRAY

--- a/oups/utils.py
+++ b/oups/utils.py
@@ -115,6 +115,7 @@ def tcut(data: Series, grouper: Grouper):
         last=data.iloc[-1],
         freq=grouper.freq,
         closed=grouper.closed,
+        unit=data.iloc[0].unit,
         origin=grouper.origin,
         offset=grouper.offset,
     )

--- a/oups/utils.py
+++ b/oups/utils.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  4 21:30:00 2021.
 
 @author: yoh
+
 """
 from os import scandir
 from typing import Iterator, List, Tuple
@@ -17,7 +18,8 @@ from oups.defines import DIR_SEP
 
 
 def files_at_depth(basepath: str, depth: int = 2) -> Iterator[Tuple[str, List[str]]]:
-    """Yield file list in dirs.
+    """
+    Yield file list in dirs.
 
     Generator yielding a tuple which:
         - 1st value is the path of a non-empty directory at 'depth' sublevel,
@@ -37,6 +39,7 @@ def files_at_depth(basepath: str, depth: int = 2) -> Iterator[Tuple[str, List[st
     Iterator[Dict[str,List[str]]]
         List of files within directory specified by the key. Empty directories
         are not returned.
+
     """
     if depth == 0:
         files = [
@@ -60,7 +63,8 @@ def files_at_depth(basepath: str, depth: int = 2) -> Iterator[Tuple[str, List[st
 
 
 def strip_path_tail(dirpath: str) -> str:
-    """Remove last level directory from provided path.
+    """
+    Remove last level directory from provided path.
 
     Parameters
     ----------
@@ -71,13 +75,15 @@ def strip_path_tail(dirpath: str) -> str:
     -------
     str
         Directory path stripped from last directory.
+
     """
     if DIR_SEP in dirpath:
         return dirpath.rsplit("/", 1)[0]
 
 
 def tcut(data: Series, grouper: Grouper):
-    """Perform binning with provided grouper.
+    """
+    Perform binning with provided grouper.
 
     Achieve binning of data by dates as specified by provided pandas grouper.
     Rows falling in same period will get same label.
@@ -109,6 +115,7 @@ def tcut(data: Series, grouper: Grouper):
     - To use results in a `groupby` operation while re-using provided grouper,
       labels (being categories), need to be materialized again as timestamps
       with ``astype('datetime64')``.
+
     """
     start, end = gtre(
         first=data.iloc[0],

--- a/oups/writer.py
+++ b/oups/writer.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  6 22:30:00 2021.
 
 @author: yoh
+
 """
 from ast import literal_eval
 from os import listdir as os_listdir
@@ -41,7 +42,8 @@ def iter_dataframe(
     sharp_on: str = None,
     duplicates_on: Union[str, List[str]] = None,
 ):
-    """Yield dataframe chunks.
+    """
+    Yield dataframe chunks.
 
     Parameters
     ----------
@@ -76,6 +78,7 @@ def iter_dataframe(
       required to set ``sharp_on`` when using ``duplicates_on``, so that
       duplicates all fall in a same row group. This implies that duplicates
       have to share the same value in ``sharp_on`` column.
+
     """
     # TODO: implement 'replicate_groups' (use of 'ordered_on' column).
     if max_row_group_size is None:
@@ -93,7 +96,7 @@ def iter_dataframe(
         if not sharp_on:
             raise ValueError(
                 "duplicates are looked for row group per group. For this reason, "
-                "it is compulsory to set 'sharp_on' while setting 'duplicates_on'."
+                "it is compulsory to set 'sharp_on' while setting 'duplicates_on'.",
             )
         elif isinstance(duplicates_on, list):
             if duplicates_on and sharp_on not in duplicates_on:
@@ -147,7 +150,8 @@ def iter_dataframe(
 
 
 def to_midx(idx: Index, levels: List[str] = None) -> MultiIndex:
-    """Expand a pandas index into a multi-index.
+    """
+    Expand a pandas index into a multi-index.
 
     Parameters
     ----------
@@ -176,6 +180,7 @@ def to_midx(idx: Index, levels: List[str] = None) -> MultiIndex:
     (resulting in fewer index levels), these column names are appended with
     empty strings '' as required to be of equal levels number than the longest
     column names.
+
     """
     idx_temp = []
     max_levels = 0
@@ -204,9 +209,12 @@ def to_midx(idx: Index, levels: List[str] = None) -> MultiIndex:
 
 
 def _update_metadata(
-    new_metadata: Dict[str, str], existing_metadata: Dict[str, str] = None, md_key: Hashable = None
+    new_metadata: Dict[str, str],
+    existing_metadata: Dict[str, str] = None,
+    md_key: Hashable = None,
 ) -> Dict[str, str]:
-    """Update oups specific metadata and merge to user-defined metadata.
+    """
+    Update oups specific metadata and merge to user-defined metadata.
 
     Parameters
     ----------
@@ -285,7 +293,8 @@ def write(
     metadata: Dict[str, str] = None,
     md_key: Hashable = None,
 ):
-    """Write data to disk at location specified by path.
+    """
+    Write data to disk at location specified by path.
 
     Parameters
     ----------
@@ -387,6 +396,7 @@ def write(
       data and without need to drop duplicates, it is advised to keep
       ``ordered_on`` and ``duplicates_on`` parameters set to ``None`` as these
       parameters will trigger unnecessary evaluations.
+
     """
     if ordered_on is not None:
         if isinstance(ordered_on, tuple):
@@ -412,7 +422,7 @@ def write(
                 raise ValueError(
                     "duplicates are looked for over the overlap between new data and existing data. "
                     "This overlap being identified thanks to 'ordered_on', "
-                    "it is compulsory to set 'ordered_on' while setting 'duplicates_on'."
+                    "it is compulsory to set 'ordered_on' while setting 'duplicates_on'.",
                 )
             # Enforce 'ordered_on' in 'duplicates_on', as per logic of
             # duplicate identification restricted to the data overlap between new
@@ -439,7 +449,9 @@ def write(
                 start = data[ordered_on][:0].to_numpy()[0]
                 end = data[ordered_on][-1:].to_numpy()[0]
             rrgs_idx = filter_row_groups(
-                pf, [[(ordered_on, ">=", start), (ordered_on, "<=", end)]], as_idx=True
+                pf,
+                [[(ordered_on, ">=", start), (ordered_on, "<=", end)]],
+                as_idx=True,
             )
             if rrgs_idx:
                 if len(rrgs_idx) == 1:
@@ -522,7 +534,8 @@ def write(
                 # Sorting row groups based on 'max' in 'ordered_on'.
                 ordered_on_idx = pf.columns.index(ordered_on)
                 pf.fmd.row_groups = sorted(
-                    pf.fmd.row_groups, key=lambda rg: statistics(rg.columns[ordered_on_idx])["max"]
+                    pf.fmd.row_groups,
+                    key=lambda rg: statistics(rg.columns[ordered_on_idx])["max"],
                 )
             # Rename partition files, and write fmd.
             pf._sort_part_names(write_fmd=False)

--- a/oups/writer.py
+++ b/oups/writer.py
@@ -4,12 +4,13 @@ Created on Wed Dec  6 22:30:00 2021.
 
 @author: yoh
 """
-import json
 from ast import literal_eval
 from os import listdir as os_listdir
 from os import path as os_path
 from typing import Dict, Hashable, List, Tuple, Union
 
+from cloudpickle import dumps
+from cloudpickle import loads
 from fastparquet import ParquetFile
 from fastparquet import write as fp_write
 from fastparquet.api import filter_row_groups
@@ -243,7 +244,7 @@ def _update_metadata(
     if existing_metadata and OUPS_METADATA_KEY in existing_metadata:
         # Case 'append' to existing metadata.
         # oups specific metadata is expected to be a dict itself.
-        consolidated_md = json.loads(existing_metadata[OUPS_METADATA_KEY])
+        consolidated_md = loads(existing_metadata[OUPS_METADATA_KEY])
         for key, value in spec_oups_md.items():
             if key in consolidated_md:
                 if value is None:
@@ -260,9 +261,9 @@ def _update_metadata(
         consolidated_md = spec_oups_md
 
     if new_metadata:
-        new_metadata[OUPS_METADATA_KEY] = json.dumps(consolidated_md)
+        new_metadata[OUPS_METADATA_KEY] = dumps(consolidated_md)
     else:
-        new_metadata = {OUPS_METADATA_KEY: json.dumps(consolidated_md)}
+        new_metadata = {OUPS_METADATA_KEY: dumps(consolidated_md)}
     if md_key:
         del OUPS_METADATA[md_key]
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ joblib = ">=1.3.2"
 numba = ">=0.58.1"
 #sortednp = "0.4.0" # remove when sortednp not used anylonger
 #dill = "^0.3.7" # use cloudpickle which is a dependency for joblib instead
-pyyaml = ">=6.0.1"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.16.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,28 +7,29 @@ license = "Apache-2.0"
 repository = "https://github.com/yohplala/oups"
 
 [tool.poetry.dependencies]
-python = ">=3.10"
-sortedcontainers = "^2.4.0"
-llvmlite = "^0.39.0" # no wheel for python 3.9 if below.
+python = ">=3.10,<3.13"
+sortedcontainers = ">=2.4.0"
+#llvmlite = "^0.39.0" # no wheel for python 3.9 if below.
 #pyarrow = "7.0.0" # force pyarrow to 6.0.1 as 7.0.0 is available, but no packages yet?
-pandas = "^1.4.4"
-cramjam = "^2.5.0"
-fastparquet = "^0.8.3"
+pandas = ">=2.1.2"
+#cramjam = "^2.5.0"
+fastparquet = ">=2023.10.1"
 #fastparquet = {git = "https://github.com/yohplala/fastparquet.git", rev = "update_custom_md"}
 #fastparquet = {git = "https://github.com/dask/fastparquet.git", rev="main"}
-vaex-core = "^4.12.0"
-vaex-server = "^0.8.1"
+vaex-core = ">=4.17.1"
+vaex-server = ">=0.8.1"
 #blake3 = "^0.2.1" # remove next time upgrading vaex
-joblib = "^1.2.0"
-numba = "^0.56.4"
+joblib = ">=1.3.2"
+numba = ">=0.58.1"
 #sortednp = "0.4.0" # remove when sortednp not used anylonger
+#dill = "^0.3.7" # use cloudpickle which is a dependency for joblib instead
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.16.0"
 pytest = "^6.2.5"
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.3.0"
+black = "^23.10.1"
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ joblib = ">=1.3.2"
 numba = ">=0.58.1"
 #sortednp = "0.4.0" # remove when sortednp not used anylonger
 #dill = "^0.3.7" # use cloudpickle which is a dependency for joblib instead
+pyyaml = "^5.4.1"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.16.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ joblib = ">=1.3.2"
 numba = ">=0.58.1"
 #sortednp = "0.4.0" # remove when sortednp not used anylonger
 #dill = "^0.3.7" # use cloudpickle which is a dependency for joblib instead
-pyyaml = "^5.4.1"
+pyyaml = ">=6.0.1"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.16.0"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  1 18:35:00 2021.
 
 @author: yoh
+
 """
 
 

--- a/tests/test_chainagg_multi.py
+++ b/tests/test_chainagg_multi.py
@@ -3,6 +3,7 @@
 Created on Sun Mar 13 18:00:00 2022.
 
 @author: yoh
+
 """
 from copy import copy
 from os import path as os_path
@@ -655,7 +656,7 @@ def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2, parallel):
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     N_third = int(N / 3)
     bin_val = np.array(
-        [1] * (N_third - 2) + [2] * (N_third - 4) + [3] * (N - 2 * N_third) + [4] * 6
+        [1] * (N_third - 2) + [2] * (N_third - 4) + [3] * (N - 2 * N_third) + [4] * 6,
     )
     ordered_on = "ts"
     bin_on = "direct_bin"
@@ -673,7 +674,12 @@ def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2, parallel):
 
     # Setup binning for key3.
     def by_4rows(data: Series, buffer: dict):
-        """Bin by group of 4 rows. Label for bins are values from `ordered_on`."""
+        """
+        Bin by group of 4 rows.
+
+        Label for bins are values from `ordered_on`.
+
+        """
         # A pandas Series is returned, with name being that of the 'ordered_on'
         # column. Because of pandas magic, this column will then be in aggregation
         # results, and oups will be able to use it for writing data.
@@ -756,7 +762,7 @@ def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2, parallel):
         | {
             key4: seed_df_trim.groupby(key_configs[key4]["bin_on"])
             .agg(**key_configs[key4]["agg"])
-            .reset_index()
+            .reset_index(),
         }
     )
     for key, ref_df in ref_res.items():
@@ -767,7 +773,11 @@ def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2, parallel):
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     seed_df2 = pDataFrame({ordered_on: ts, "val": rand_ints + 100, bin_on: bin_val + 10})
     fp_write(
-        seed_path, seed_df2, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+        seed_path,
+        seed_df2,
+        row_group_offsets=max_row_group_size,
+        file_scheme="hive",
+        append=True,
     )
     seed = ParquetFile(seed_path)
     # Setup streamed aggregation.
@@ -796,7 +806,7 @@ def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2, parallel):
         | {
             key4: seed_df2_ref.groupby(key_configs[key4]["bin_on"])
             .agg(**key_configs[key4]["agg"])
-            .reset_index()
+            .reset_index(),
         }
     )
     for key, ref_df in ref_res.items():
@@ -807,7 +817,11 @@ def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2, parallel):
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     seed_df3 = pDataFrame({ordered_on: ts, "val": rand_ints + 400, bin_on: bin_val + 40})
     fp_write(
-        seed_path, seed_df3, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+        seed_path,
+        seed_df3,
+        row_group_offsets=max_row_group_size,
+        file_scheme="hive",
+        append=True,
     )
     seed = ParquetFile(seed_path)
     # Setup streamed aggregation.
@@ -836,7 +850,7 @@ def test_parquet_seed_3_keys(tmp_path, reduction1, reduction2, parallel):
         | {
             key4: seed_df3_ref.groupby(key_configs[key4]["bin_on"])
             .agg(**key_configs[key4]["agg"])
-            .reset_index()
+            .reset_index(),
         }
     )
     for key, ref_df in ref_res.items():
@@ -862,7 +876,7 @@ def test_exception_setup_no_bin_on_nor_by(tmp_path):
     # Test.
     with pytest.raises(ValueError, match="^at least one among"):
         (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
-            **parameter_in
+            **parameter_in,
         )
 
 
@@ -884,7 +898,7 @@ def test_exception_setup_no_bin_on_nor_by_key_when_grouper(tmp_path):
     # Test.
     with pytest.raises(ValueError, match="^no column name defined to bin"):
         (all_cols_in, trim_start, seed_index_restart_set, reduction_agg, keys_config_res) = _setup(
-            **parameter_in
+            **parameter_in,
         )
 
 
@@ -927,7 +941,11 @@ def test_exception_different_index_at_restart(tmp_path):
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     seed_df2 = pDataFrame({ordered_on: ts, "val": rand_ints + 100})
     fp_write(
-        seed_path, seed_df2, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+        seed_path,
+        seed_df2,
+        row_group_offsets=max_row_group_size,
+        file_scheme="hive",
+        append=True,
     )
     seed = ParquetFile(seed_path)
     # Streamagg with 'key2'.
@@ -950,14 +968,19 @@ def test_exception_different_index_at_restart(tmp_path):
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     seed_df3 = pDataFrame({ordered_on: ts, "val": rand_ints + 400})
     fp_write(
-        seed_path, seed_df3, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+        seed_path,
+        seed_df3,
+        row_group_offsets=max_row_group_size,
+        file_scheme="hive",
+        append=True,
     )
     seed = ParquetFile(seed_path)
     # Streamagg with 'key1' and 'key2'.
     key_configs = {key1: key1_cf, key2: key2_cf}
     # Test.
     with pytest.raises(
-        ValueError, match="^not possible to aggregate on multiple keys with existing"
+        ValueError,
+        match="^not possible to aggregate on multiple keys with existing",
     ):
         chainagg(
             seed=seed,

--- a/tests/test_chainagg_simple.py
+++ b/tests/test_chainagg_simple.py
@@ -3,6 +3,7 @@
 Created on Sun Mar 13 18:00:00 2022.
 
 @author: yoh
+
 """
 from os import path as os_path
 
@@ -92,7 +93,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
             date + "13:40",
             date + "14:00",
             date + "14:20",
-        ]
+        ],
     )
     ordered_on = "ts"
     seed_df = pDataFrame({ordered_on: ts, "val": range(1, len(ts) + 1)})
@@ -137,7 +138,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
             date + "12:00",
             date + "13:00",
             date + "14:00",
-        ]
+        ],
     )
     ref_res = pDataFrame({ordered_on: dti_ref, agg_col: agg_sum_ref})
     rec_res = store[key].pdf
@@ -201,7 +202,7 @@ def test_parquet_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
             date + "13:00",
             date + "14:00",
             date + "15:00",
-        ]
+        ],
     )
     ref_res = pDataFrame({ordered_on: dti_ref, agg_col: agg_sum_ref})
     rec_res = store[key].pdf
@@ -307,7 +308,7 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
             date + "13:40",
             date + "14:00",
             date + "14:20",
-        ]
+        ],
     )
     ordered_on = "ts"
     seed_pdf = pDataFrame({ordered_on: ts, "val": range(1, len(ts) + 1)})
@@ -348,7 +349,7 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
             date + "12:00",
             date + "13:00",
             date + "14:00",
-        ]
+        ],
     )
     agg_sum_ref = [3, 7, 18, 17, 33, 42, 16]
     ref_res = pDataFrame({ordered_on: dti_ref, agg_col: agg_sum_ref})
@@ -408,7 +409,7 @@ def test_vaex_seed_time_grouper_sum_agg(tmp_path, reduction1, reduction2):
             date + "13:00",
             date + "14:00",
             date + "15:00",
-        ]
+        ],
     )
     ref_res = pDataFrame({ordered_on: dti_ref, agg_col: agg_sum_ref})
     rec_res = store[key].pdf
@@ -440,7 +441,7 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path, reduction1, 
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     ordered_on = "ts"
     seed_df = pDataFrame(
-        {ordered_on: ts + ts, "val": np.append(rand_ints, rand_ints + 1)}
+        {ordered_on: ts + ts, "val": np.append(rand_ints, rand_ints + 1)},
     ).sort_values(ordered_on)
     seed_path = os_path.join(tmp_path, "seed")
     fp_write(seed_path, seed_df, row_group_offsets=max_row_group_size, file_scheme="hive")
@@ -478,7 +479,11 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path, reduction1, 
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     seed_df2 = pDataFrame({ordered_on: ts, "val": rand_ints + 100}).sort_values(ordered_on)
     fp_write(
-        seed_path, seed_df2, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+        seed_path,
+        seed_df2,
+        row_group_offsets=max_row_group_size,
+        file_scheme="hive",
+        append=True,
     )
     seed = ParquetFile(seed_path)
     # Setup streamed aggregation.
@@ -502,7 +507,11 @@ def test_parquet_seed_time_grouper_first_last_min_max_agg(tmp_path, reduction1, 
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     seed_df3 = pDataFrame({ordered_on: ts, "val": rand_ints + 400}).sort_values(ordered_on)
     fp_write(
-        seed_path, seed_df3, row_group_offsets=max_row_group_size, file_scheme="hive", append=True
+        seed_path,
+        seed_df3,
+        row_group_offsets=max_row_group_size,
+        file_scheme="hive",
+        append=True,
     )
     seed = ParquetFile(seed_path)
     # Setup streamed aggregation.
@@ -679,7 +688,7 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path, reduction1, red
             date + "13:40",
             date + "14:00",
             date + "14:20",
-        ]
+        ],
     )
     ordered_on = "ts"
     weights = [1, 2, 1, 0, 2, 1, 2, 1, 0, 3, 2, 1, 3, 0, 1, 2, 1]
@@ -705,7 +714,9 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path, reduction1, red
 
     # Setup 'post'.
     def post(agg_res: pDataFrame, isfbn: bool, post_buffer: dict):
-        """Compute duration, weighted mean and keep track of data to buffer."""
+        """
+        Compute duration, weighted mean and keep track of data to buffer.
+        """
         # Compute 'duration'.
         agg_res["last"] = (agg_res["last"] - agg_res["first"]).view("int64")
         # Compute 'weighted_mean'.
@@ -784,12 +795,16 @@ def test_parquet_seed_duration_weighted_mean_from_post(tmp_path, reduction1, red
     rand_ints = rr.integers(600, size=N)
     ts = [start + Timedelta(f"{mn}T") for mn in rand_ints]
     seed_df2 = pDataFrame(
-        {ordered_on: ts, "val": rand_ints + 100, "weight": rand_ints}
+        {ordered_on: ts, "val": rand_ints + 100, "weight": rand_ints},
     ).sort_values(ordered_on)
     # Setup weighted mean: need 'weight' x 'val'.
     seed_df2["weighted_val"] = seed_df2["weight"] * seed_df2["val"]
     fp_write(
-        seed_path, seed_df2, row_group_offsets=row_group_offsets, file_scheme="hive", append=True
+        seed_path,
+        seed_df2,
+        row_group_offsets=row_group_offsets,
+        file_scheme="hive",
+        append=True,
     )
     seed = ParquetFile(seed_path)
     # Setup streamed aggregation.
@@ -834,7 +849,7 @@ def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path, reduction1, reducti
             date + "11:00",
             date + "11:30",
             date + "12:00",
-        ]
+        ],
     )
     ordered_on = "ts"
     bin_on = "ts_bin"
@@ -888,7 +903,7 @@ def test_parquet_seed_time_grouper_bin_on_as_tuple(tmp_path, reduction1, reducti
     # 1st append of new data.
     ts2 = DatetimeIndex([date + "12:30", date + "13:00", date + "13:30", date + "14:00"])
     seed_pdf2 = pDataFrame(
-        {ordered_on: ts2, bin_on: ts2, "val": range(len(ts) + 1, len(ts) + len(ts2) + 1)}
+        {ordered_on: ts2, bin_on: ts2, "val": range(len(ts) + 1, len(ts) + len(ts2) + 1)},
     )
     fp_write(seed_path, seed_pdf2, file_scheme="hive", append=True)
     seed = ParquetFile(seed_path)
@@ -970,7 +985,7 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path, reduction1, reduction2):
             date + "14:00",
             date + "14:20",
             date + "14:20",
-        ]
+        ],
     )
     ordered_on = "ts"
     seed_pdf = pDataFrame({ordered_on: ts, "val": range(1, len(ts) + 1)})
@@ -984,7 +999,12 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path, reduction1, reduction2):
 
     # Setup binning.
     def by_4rows(data: Series, buffer: dict):
-        """Bin by group of 4 rows. Label for bins are values from `ordered_on`."""
+        """
+        Bin by group of 4 rows.
+
+        Label for bins are values from `ordered_on`.
+
+        """
         # A pandas Series is returned, with name being that of the 'ordered_on'
         # column. Because of pandas magic, this column will then be in aggregation
         # results, and oups will be able to use it for writing data.
@@ -1087,7 +1107,7 @@ def test_vaex_seed_by_callable_wo_bin_on(tmp_path, reduction1, reduction2):
             date + "16:00",
             date + "16:40",
             date + "16:40",
-        ]
+        ],
     )
     seed_pdf2 = pDataFrame({ordered_on: ts2, "val": range(1, len(ts2) + 1)})
     # Forcing dtype of 'seed_pdf' to float.
@@ -1181,7 +1201,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
             date + "14:00",
             date + "14:20",
             date + "14:20",
-        ]
+        ],
     )
     ordered_on = "ts"
     bin_on = "val"
@@ -1199,7 +1219,9 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
 
     # Setup binning.
     def by_1val(data: pDataFrame, buffer: dict):
-        """Start a new bin each time a 1 is spot."""
+        """
+        Start a new bin each time a 1 is spot.
+        """
         # A pandas Series is returned.
         # Its name does not matter as 'bin_on' in chainagg is a tuple which
         # 2nd item will define the column name for group keys.
@@ -1264,7 +1286,7 @@ def test_vaex_seed_by_callable_with_bin_on(tmp_path, reduction1, reduction2):
             date + "16:00",
             date + "16:40",
             date + "16:40",
-        ]
+        ],
     )
     val = np.arange(1, len(ts2) + 1)
     val[3] = 1
@@ -1545,7 +1567,13 @@ def test_parquet_seed_single_row(tmp_path, reduction):
     agg = {"sum": ("val", "sum")}
     # Streamed aggregation: no aggregation, but no error message.
     chainagg(
-        seed=seed, ordered_on=ordered_on, agg=agg, store=store, keys=key, by=by, reduction=reduction
+        seed=seed,
+        ordered_on=ordered_on,
+        agg=agg,
+        store=store,
+        keys=key,
+        by=by,
+        reduction=reduction,
     )
     # Test results.
     assert key not in store
@@ -1600,7 +1628,7 @@ def test_parquet_seed_single_row_within_seed(tmp_path, reduction):
             date + "14:00",
             date + "14:20",
             date + "14:20",
-        ]
+        ],
     )
     ordered_on = "ts"
     val = np.arange(1, len(ts) + 1)
@@ -1617,7 +1645,13 @@ def test_parquet_seed_single_row_within_seed(tmp_path, reduction):
     agg = {"sum": ("val", "sum")}
     # Streamed aggregation: no aggregation, but no error message.
     chainagg(
-        seed=seed, ordered_on=ordered_on, agg=agg, store=store, keys=key, by=by, reduction=reduction
+        seed=seed,
+        ordered_on=ordered_on,
+        agg=agg,
+        store=store,
+        keys=key,
+        by=by,
+        reduction=reduction,
     )
     # Test results.
     ref_res = seed_pdf.iloc[:-2].groupby(by).agg(**agg).reset_index()
@@ -1648,7 +1682,9 @@ def test_vaex_seed_time_grouper_duplicates_on_wo_bin_on(tmp_path, reduction):
     agg = {"sum": ("val", "sum")}
 
     def post(agg_res: pDataFrame, isfbn: bool, post_buffer: dict):
-        """Remove 'bin_on' column."""
+        """
+        Remove 'bin_on' column.
+        """
         # Rename column 'bin_on' into 'ordered_on' to have an 'ordered_on'
         # column, while 'removing' 'bin_on' one.
         agg_res.rename(

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  1 18:35:00 2021.
 
 @author: yoh
+
 """
 import zipfile
 from os import path as os_path
@@ -97,7 +98,7 @@ def test_set_parquet(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 10:00", freq="2H"),
             "temperature": [8.4, 5.3],
-        }
+        },
     )
     ps[we] = df
     assert we in ps
@@ -114,7 +115,7 @@ def test_set_parquet_with_config(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             "temperature": [8.4, 5.3, 4.9, 2.3],
-        }
+        },
     )
     rg_size = 2
     config = {"max_row_group_size": rg_size}
@@ -134,7 +135,7 @@ def test_exception_config_not_a_dict(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             "temperature": [8.4, 5.3, 4.9, 2.3],
-        }
+        },
     )
     config = []  # First silly thing that comes to mind.
     with pytest.raises(TypeError, match="^first item"):
@@ -161,7 +162,7 @@ def test_iterator(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             "temperature": [8.4, 5.3, 4.9, 2.3],
-        }
+        },
     )
     ps[we1], ps[we2] = df, df
     for key in ps:
@@ -176,7 +177,7 @@ def test_set_and_get_roundtrip_pandas(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             "temperature": [8.4, 5.3, 2.9, 6.4],
-        }
+        },
     )
     config = {"max_row_group_size": 2}
     ps[we] = config, df
@@ -192,7 +193,7 @@ def test_set_pandas_and_get_vaex(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             "temperature": [8.4, 5.3, 2.9, 6.4],
-        }
+        },
     )
     config = {"max_row_group_size": 2}
     ps[we] = config, df
@@ -208,7 +209,7 @@ def test_set_pandas_and_get_parquet_file(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             "temperature": [8.4, 5.3, 2.9, 6.4],
-        }
+        },
     )
     config = {"max_row_group_size": 2}
     ps[we] = config, df
@@ -224,10 +225,11 @@ def test_set_cmidx_get_vaex(tmp_path):
             ("ts", ""): date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             ("temp", "1"): [8.4, 5.3, 2.9, 6.4],
             ("temp", "2"): [8.4, 5.3, 2.9, 6.4],
-        }
+        },
     )
     pdf.columns = MultiIndex.from_tuples(
-        [("ts", ""), ("temp", "1"), ("temp", "2")], names=["component", "point"]
+        [("ts", ""), ("temp", "1"), ("temp", "2")],
+        names=["component", "point"],
     )
     ps = ParquetSet(tmp_path, WeatherEntry)
     we = WeatherEntry("paris", "temperature", SpaceTime("notredame", "winter"))
@@ -250,7 +252,7 @@ def test_dataset_removal(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
             "temperature": [8.4, 5.3, 4.9, 2.3],
-        }
+        },
     )
     ps[we1], ps[we2], ps[we3] = df, df, df
     # Delete london-related data.
@@ -281,7 +283,7 @@ def test_11_rgs_pandas_to_vaex(tmp_path):
         {
             "timestamp": date_range("2021/01/01 08:00", freq="2H", periods=len(temp)),
             "temperature": temp,
-        }
+        },
     )
     config = {"max_row_group_size": 1}
     ps[we] = config, df

--- a/tests/test_cumsegagg.py
+++ b/tests/test_cumsegagg.py
@@ -3,6 +3,7 @@
 Created on Sun Mar 13 18:00:00 2022.
 
 @author: yoh
+
 """
 from functools import partial
 
@@ -66,7 +67,7 @@ def test_setup_csagg():
                 pTimestamp("2022/01/01 09:00"),
                 pTimestamp("2022/01/01 08:00"),
             ],
-        }
+        },
     )
     agg_cfg = {
         "val1_first": ("val1_float", FIRST),
@@ -190,7 +191,7 @@ def test_cumsegagg_bin_single_dtype(ndata, cols):
                 "col1": ndata[:, 0],
                 "col2": ndata[:, 1],
                 time_idx: ndata_dti,
-            }
+            },
         )
         agg = {
             "res_first": ("col1", "first"),
@@ -203,7 +204,7 @@ def test_cumsegagg_bin_single_dtype(ndata, cols):
             {
                 "col1_f": ndata,
                 time_idx: ndata_dti,
-            }
+            },
         )
         agg = {"res_first": ("col1_f", "first"), "res_last": ("col1_f", "last")}
     by = Grouper(freq="5T", closed="left", label="left", key=time_idx)
@@ -215,7 +216,8 @@ def test_cumsegagg_bin_single_dtype(ndata, cols):
 def test_cumsegagg_bin_mixed_dtype():
     # Test binning aggregation for a mixed dtype.
     ar_float = array(
-        [[2.0, 20.0], [4.0, 40.0], [5.0, 50.0], [8.0, 80.0], [9.0, 90.0]], dtype=DTYPE_FLOAT64
+        [[2.0, 20.0], [4.0, 40.0], [5.0, 50.0], [8.0, 80.0], [9.0, 90.0]],
+        dtype=DTYPE_FLOAT64,
     )
     ar_int = array([[1, 10], [3, 30], [6, 60], [7, 70], [9, 90]], dtype=DTYPE_INT64)
     ar_dti = array(
@@ -236,7 +238,7 @@ def test_cumsegagg_bin_mixed_dtype():
             "col3_i": ar_int[:, 0],
             "col4_i": ar_int[:, 1],
             time_idx: ar_dti,
-        }
+        },
     )
     agg = {
         "res_first_f": ("col1_f", "first"),
@@ -785,7 +787,7 @@ def test_cumsegagg_several_null_snaps_at_start_of_bins(s_by_closed, s_res):
             pTimestamp("2020-01-01 09:06:00"),
             pTimestamp("2020-01-01 09:09:00"),
             pTimestamp("2020-01-01 09:16:00"),
-        ]
+        ],
     )
     bins_res, snaps_res = cumsegagg(
         data=data,
@@ -870,7 +872,12 @@ def test_cumsegagg_several_null_snaps_at_start_of_bins(s_by_closed, s_res):
     ],
 )
 def test_cumsegagg_binby_grouper_snapby_intervalindex(
-    b_by_closed, b_by_label, s_first_val, s_max_val, s_min_val, s_last_val
+    b_by_closed,
+    b_by_label,
+    s_first_val,
+    s_max_val,
+    s_min_val,
+    s_last_val,
 ):
     # Test binning and snapshotting aggregation with null chunks.
     # - 30 minutes bins
@@ -907,7 +914,7 @@ def test_cumsegagg_binby_grouper_snapby_intervalindex(
             pTimestamp("2020-01-01 08:20:00"),
             pTimestamp("2020-01-01 08:50:00"),
             pTimestamp("2020-01-01 09:06:00"),
-        ]
+        ],
     )
     bins_res, snaps_res = cumsegagg(
         data=data,
@@ -992,7 +999,11 @@ def test_cumsegagg_binby_grouper_snapby_intervalindex(
     ],
 )
 def test_cumsegagg_binby_callable_snapby_intervalindex(
-    b_by_closed, s_first_val, s_max_val, s_min_val, s_last_val
+    b_by_closed,
+    s_first_val,
+    s_max_val,
+    s_min_val,
+    s_last_val,
 ):
     # Test binning and snapshotting aggregation with null chunks.
     # - 4-row bins
@@ -1028,7 +1039,7 @@ def test_cumsegagg_binby_callable_snapby_intervalindex(
             pTimestamp("2020-01-01 08:20:00"),
             pTimestamp("2020-01-01 08:50:00"),
             pTimestamp("2020-01-01 09:06:00"),
-        ]
+        ],
     )
     bin_by = partial(by_x_rows, closed=b_by_closed)
     bins_res, snaps_res = cumsegagg(

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  1 18:35:00 2021.
 
 @author: yoh
+
 """
 from dataclasses import FrozenInstanceError
 from dataclasses import asdict

--- a/tests/test_jcumsegagg.py
+++ b/tests/test_jcumsegagg.py
@@ -3,6 +3,7 @@
 Created on Sun Mar 13 18:00:00 2022.
 
 @author: yoh
+
 """
 import pytest
 from numpy import all as nall
@@ -777,7 +778,8 @@ def test_jcsagg_bin_snap_1d(
     #                      s0 b0 s1 b1 s2 b2 s3 s4 b3 s5 s6 b4 b5 s7 s8  s9  b6 s10 s11
     # next_chunk_starts = [ 0, 0, 1, 3, 4, 4, 4, 4, 4, 5, 5, 7, 7, 8, 8, 10, 10, 10, 10]
     next_chunk_starts = array(
-        [0, 0, 1, 3, 4, 4, 4, 4, 4, 5, 5, 7, 7, 8, 8, 10, 10, 10, 10], dtype=INT64
+        [0, 0, 1, 3, 4, 4, 4, 4, 4, 5, 5, 7, 7, 8, 8, 10, 10, 10, 10],
+        dtype=INT64,
     )
     bin_indices = array(bin_indices_, dtype=INT64)
     chunk_res = ones(N_AGG_COLS, dtype=dtype_)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,6 +3,7 @@
 Created on Sat Dec 18 15:00:00 2021.
 
 @author: yoh
+
 """
 from pandas import DataFrame as pDataFrame
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3,6 +3,7 @@
 Created on Sat Dec 18 15:00:00 2021.
 
 @author: yoh
+
 """
 import zipfile
 from os import path as os_path
@@ -24,7 +25,7 @@ df_ref = pDataFrame(
     {
         "timestamp": date_range("2021/01/01 08:00", "2021/01/01 14:00", freq="2H"),
         "temperature": [8.4, 5.3, 4.9, 2.3],
-    }
+    },
 )
 
 

--- a/tests/test_segmentby.py
+++ b/tests/test_segmentby.py
@@ -3,6 +3,7 @@
 Created on Sun Mar 13 18:00:00 2022.
 
 @author: yoh
+
 """
 from functools import partial
 
@@ -12,10 +13,10 @@ from numpy import arange
 from numpy import array
 from pandas import DataFrame as pDataFrame
 from pandas import DatetimeIndex
-from pandas import Grouper
 from pandas import Series
 from pandas import Timestamp as pTimestamp
 from pandas import date_range
+from pandas.core.resample import TimeGrouper
 
 from oups.segmentby import BIN_BY
 from oups.segmentby import DTYPE_DATETIME64
@@ -128,16 +129,20 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:00"),
                     pTimestamp("2020/01/01 08:04"),
                     pTimestamp("2020/01/01 08:05"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="left", closed="left"),
+            TimeGrouper(freq="5T", label="left", closed="left"),
             DatetimeIndex(
-                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
             array([2, 3], dtype=DTYPE_INT64),
             0,
             DatetimeIndex(
-                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
         ),
         (
@@ -146,9 +151,9 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:00"),
                     pTimestamp("2020/01/01 08:03"),
                     pTimestamp("2020/01/01 08:04"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="left", closed="left"),
+            TimeGrouper(freq="5T", label="left", closed="left"),
             DatetimeIndex(["2020-01-01 08:00:00"], dtype=DTYPE_DATETIME64, freq="5T"),
             array([3], dtype=DTYPE_INT64),
             0,
@@ -160,16 +165,20 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:01"),
                     pTimestamp("2020/01/01 08:03"),
                     pTimestamp("2020/01/01 08:05"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="left", closed="left"),
+            TimeGrouper(freq="5T", label="left", closed="left"),
             DatetimeIndex(
-                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
             array([2, 3], dtype=DTYPE_INT64),
             0,
             DatetimeIndex(
-                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
         ),
         (
@@ -178,16 +187,20 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:00"),
                     pTimestamp("2020/01/01 08:03"),
                     pTimestamp("2020/01/01 08:05"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="right", closed="left"),
+            TimeGrouper(freq="5T", label="right", closed="left"),
             DatetimeIndex(
-                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
             array([2, 3], dtype=DTYPE_INT64),
             0,
             DatetimeIndex(
-                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:05:00", "2020-01-01 08:10:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
         ),
         (
@@ -196,9 +209,9 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:00"),
                     pTimestamp("2020/01/01 08:03"),
                     pTimestamp("2020/01/01 08:04"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="right", closed="left"),
+            TimeGrouper(freq="5T", label="right", closed="left"),
             DatetimeIndex(["2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"),
             array([3], dtype=DTYPE_INT64),
             0,
@@ -210,16 +223,20 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:00"),
                     pTimestamp("2020/01/01 08:04"),
                     pTimestamp("2020/01/01 08:05"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="left", closed="right"),
+            TimeGrouper(freq="5T", label="left", closed="right"),
             DatetimeIndex(
-                ["2020-01-01 07:55:00", "2020-01-01 08:00:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 07:55:00", "2020-01-01 08:00:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
             array([1, 3], dtype=DTYPE_INT64),
             0,
             DatetimeIndex(
-                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
         ),
         (
@@ -228,16 +245,20 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:00"),
                     pTimestamp("2020/01/01 08:03"),
                     pTimestamp("2020/01/01 08:04"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="left", closed="right"),
+            TimeGrouper(freq="5T", label="left", closed="right"),
             DatetimeIndex(
-                ["2020-01-01 07:55:00", "2020-01-01 08:00:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 07:55:00", "2020-01-01 08:00:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
             array([1, 3], dtype=DTYPE_INT64),
             0,
             DatetimeIndex(
-                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
         ),
         (
@@ -246,9 +267,9 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:01"),
                     pTimestamp("2020/01/01 08:03"),
                     pTimestamp("2020/01/01 08:04"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="left", closed="right"),
+            TimeGrouper(freq="5T", label="left", closed="right"),
             DatetimeIndex(["2020-01-01 08:00:00"], dtype=DTYPE_DATETIME64, freq="5T"),
             array([3], dtype=DTYPE_INT64),
             0,
@@ -260,16 +281,20 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:00"),
                     pTimestamp("2020/01/01 08:04"),
                     pTimestamp("2020/01/01 08:05"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="right", closed="right"),
+            TimeGrouper(freq="5T", label="right", closed="right"),
             DatetimeIndex(
-                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
             array([1, 3], dtype=DTYPE_INT64),
             0,
             DatetimeIndex(
-                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"
+                ["2020-01-01 08:00:00", "2020-01-01 08:05:00"],
+                dtype=DTYPE_DATETIME64,
+                freq="5T",
             ),
         ),
         (
@@ -278,9 +303,9 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
                     pTimestamp("2020/01/01 08:01"),
                     pTimestamp("2020/01/01 08:03"),
                     pTimestamp("2020/01/01 08:04"),
-                ]
+                ],
             ),
-            Grouper(freq="5T", label="right", closed="right"),
+            TimeGrouper(freq="5T", label="right", closed="right"),
             DatetimeIndex(["2020-01-01 08:05:00"], dtype=DTYPE_DATETIME64, freq="5T"),
             array([3], dtype=DTYPE_INT64),
             0,
@@ -289,7 +314,12 @@ def test_next_chunk_starts(data, right_edges, right, ref, n_null_chunks_ref, edg
     ],
 )
 def test_by_scale(
-    on, by, chunk_labels_ref, next_chunk_starts_ref, n_null_chunks_ref, chunk_ends_ref
+    on,
+    by,
+    chunk_labels_ref,
+    next_chunk_starts_ref,
+    n_null_chunks_ref,
+    chunk_ends_ref,
 ):
     # next_chunk_starts, chunk_labels, n_null_chunks, by_closed, chunk_ends, False
     (
@@ -351,7 +381,7 @@ def test_by_x_rows(
     start = pTimestamp("2022/01/01 08:00")
     dummy_data = arange(len_data)
     data = pDataFrame(
-        {"dummy_data": dummy_data, "dti": date_range(start, periods=len_data, freq="1H")}
+        {"dummy_data": dummy_data, "dti": date_range(start, periods=len_data, freq="1H")},
     )
     chunk_labels_ref = data.iloc[chunk_starts_ref, -1].reset_index(drop=True)
     chunk_ends_idx = next_chunk_starts_ref.copy()
@@ -443,7 +473,7 @@ def test_mergesort_exceptions_array_length(labels1, labels2, exception_mess):
     "bin_by, bin_on, ordered_on, snap_by, on_cols_ref, ordered_on_ref, next_chunk_starts_ref",
     [
         (
-            Grouper(key="dti", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti", freq="5T", label="left", closed="left"),
             None,
             None,
             None,
@@ -452,7 +482,7 @@ def test_mergesort_exceptions_array_length(labels1, labels2, exception_mess):
             array([2, 3]),
         ),
         (
-            Grouper(key="dti", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti", freq="5T", label="left", closed="left"),
             "dti",
             None,
             None,
@@ -461,7 +491,7 @@ def test_mergesort_exceptions_array_length(labels1, labels2, exception_mess):
             array([2, 3]),
         ),
         (
-            Grouper(key="dti", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti", freq="5T", label="left", closed="left"),
             None,
             "dti",
             None,
@@ -491,7 +521,7 @@ def test_mergesort_exceptions_array_length(labels1, labels2, exception_mess):
             by_x_rows,
             "dti",
             None,
-            Grouper(key="dti2", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti2", freq="5T", label="left", closed="left"),
             ["dti", "dti2"],
             "dti2",
             array([3]),
@@ -499,15 +529,21 @@ def test_mergesort_exceptions_array_length(labels1, labels2, exception_mess):
     ],
 )
 def test_setup_segmentby(
-    bin_by, bin_on, ordered_on, snap_by, on_cols_ref, ordered_on_ref, next_chunk_starts_ref
+    bin_by,
+    bin_on,
+    ordered_on,
+    snap_by,
+    on_cols_ref,
+    ordered_on_ref,
+    next_chunk_starts_ref,
 ):
     # Input data for testing 'bin_by' callable.
     res = setup_segmentby(bin_by, bin_on, ordered_on, snap_by)
-    if isinstance(bin_by, Grouper):
+    if isinstance(bin_by, TimeGrouper):
         on = Series(date_range("2020/01/01 08:01", periods=3, freq="3T"))
     else:
         on = pDataFrame(
-            {"dti": date_range("2020/01/01 08:01", periods=3, freq="3T"), "ordered_on": [1, 2, 3]}
+            {"dti": date_range("2020/01/01 08:01", periods=3, freq="3T"), "ordered_on": [1, 2, 3]},
         )
     (next_chunk_starts, _, _, _, _, _) = res[BIN_BY](on=on)
     assert nall(next_chunk_starts == next_chunk_starts_ref)
@@ -519,21 +555,21 @@ def test_setup_segmentby(
     "bin_by, bin_on, ordered_on, snap_by, regex_ref",
     [
         (
-            Grouper(key=None, freq="5T", label="left", closed="left"),
+            TimeGrouper(key=None, freq="5T", label="left", closed="left"),
             None,
             None,
             None,
             "^not possible to set both 'bin_by.key' and 'bin_on'",
         ),
         (
-            Grouper(key="dti1", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti1", freq="5T", label="left", closed="left"),
             "dti2",
             None,
             None,
             "^not possible to set 'bin_by.key' and 'bin_on'",
         ),
         (
-            Grouper(key="dti1", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti1", freq="5T", label="left", closed="left"),
             None,
             "dti2",
             None,
@@ -547,17 +583,17 @@ def test_setup_segmentby(
             "not possible to set both 'bin_on' and 'ordered_on'.",
         ),
         (
-            Grouper(key="dti1", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti1", freq="5T", label="left", closed="left"),
             None,
             None,
-            Grouper(key="dti2", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti2", freq="5T", label="left", closed="left"),
             "^not possible to set 'ordered_on' and 'snap_by.key'",
         ),
         (
-            Grouper(key="dti", freq="5T", label="left", closed="left"),
+            TimeGrouper(key="dti", freq="5T", label="left", closed="left"),
             None,
             None,
-            Grouper(key="dti", freq="5T", label="left", closed="right"),
+            TimeGrouper(key="dti", freq="5T", label="left", closed="right"),
             "^not possible to set 'bin_by.closed' and 'snap_by.closed'",
         ),
         (
@@ -579,8 +615,8 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
     "bin_labels_ref, n_null_bins_ref, snap_labels_ref, n_max_null_snaps_ref",
     [
         (
-            # 0/ 'bin_by' only, as a Grouper.
-            Grouper(key="dti", freq="5T", label="left", closed="left"),
+            # 0/ 'bin_by' only, as a TimeGrouper.
+            TimeGrouper(key="dti", freq="5T", label="left", closed="left"),
             None,
             None,
             None,
@@ -592,7 +628,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             0,
         ),
         (
-            # 1/ 'bin_by' and 'snap_by' both as a Grouper, left-closed
+            # 1/ 'bin_by' and 'snap_by' both as a TimeGrouper, left-closed
             # 'snap_by' points excluded (left-closed)
             # 'data'
             #  datetime       snaps       bins
@@ -601,10 +637,10 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             #               s3-8:10    b2
             #      8:10     s4-8:12    b3-8:15
             #      8:13     s5-8:14    b3
-            Grouper(key="dti", freq="5T", label="right", closed="left"),
+            TimeGrouper(key="dti", freq="5T", label="right", closed="left"),
             None,
             None,
-            Grouper(key="dti", freq="2T", label="right"),
+            TimeGrouper(key="dti", freq="2T", label="right"),
             #     b1 s1 s2 s3 b2 s4 s5 b3
             #      0           4        7
             array([1, 1, 2, 2, 2, 3, 4, 4]),
@@ -615,7 +651,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             2,
         ),
         (
-            # 2/ 'bin_by' and 'snap_by' both as a Grouper, right-closed
+            # 2/ 'bin_by' and 'snap_by' both as a TimeGrouper, right-closed
             # 'snap_by' points included (right-closed)
             # 'data'
             #  datetime       snaps       bins
@@ -625,10 +661,10 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             #      8:10     s4-8:10    b2
             #               s5-8:12    b3-8:15
             #      8:13     s6-8:14    b3
-            Grouper(key="dti", freq="5T", label="right", closed="right"),
+            TimeGrouper(key="dti", freq="5T", label="right", closed="right"),
             None,
             None,
-            Grouper(key="dti", freq="2T", label="right", closed="right"),
+            TimeGrouper(key="dti", freq="2T", label="right", closed="right"),
             #     s1 b1 s2 s3 s4 b2 s5 s6 b3
             #         1           5        8
             array([1, 1, 1, 2, 3, 3, 3, 4, 4]),
@@ -642,7 +678,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             4,
         ),
         (
-            # 3/ 'bin_by' as a Grouper, left-closed, and 'snap_by' as a
+            # 3/ 'bin_by' as a TimeGrouper, left-closed, and 'snap_by' as a
             # DatetimeIndex.
             # 'snap_by' points excluded (left-closed)
             # 'data'
@@ -652,7 +688,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             #               s3-8:10    b2
             #      8:10     s4-8:12    b3-8:15
             #      8:13     s5-8:14    b3
-            Grouper(key="dti", freq="5T", label="right", closed="left"),
+            TimeGrouper(key="dti", freq="5T", label="right", closed="left"),
             None,
             None,
             date_range("2020/01/01 08:06", periods=5, freq="2T"),
@@ -666,7 +702,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             2,
         ),
         (
-            # 4/ 'bin_by' as a Grouper, right-closed, and 'snap_by' as a
+            # 4/ 'bin_by' as a TimeGrouper, right-closed, and 'snap_by' as a
             # DatetimeIndex.
             # 'snap_by' points included (right-closed)
             # 'data'
@@ -677,7 +713,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             #      8:10     s4-8:10    b2
             #               s5-8:12    b3-8:15
             #      8:13     s6-8:14    b3
-            Grouper(key="dti", freq="5T", label="right", closed="right"),
+            TimeGrouper(key="dti", freq="5T", label="right", closed="right"),
             None,
             None,
             date_range("2020/01/01 08:04", periods=6, freq="2T"),
@@ -695,7 +731,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
         ),
         (
             # 5/ 'bin_by' as a Callable, left-closed.
-            # 'snap_by' as a Grouper, points excluded (left-closed)
+            # 'snap_by' as a TimeGrouper, points excluded (left-closed)
             # 'data'
             #  datetime       snaps       bins
             #      8:04     s1-8:06    b1-8:06
@@ -707,7 +743,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             partial(by_x_rows, by=3),
             "dti",
             None,
-            Grouper(key="dti", freq="2T", label="right"),
+            TimeGrouper(key="dti", freq="2T", label="right"),
             #     s1 s2 s3 s4 b1 s5 b2
             #                  4     6
             array([1, 2, 2, 3, 3, 4, 4]),
@@ -721,7 +757,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
         ),
         (
             # 6/ 'bin_by' as a Callable, right-closed.
-            # 'snap_by' as a Grouper, points included (right-closed)
+            # 'snap_by' as a TimeGrouper, points included (right-closed)
             # 'data'
             #  datetime       snaps       bins
             #      8:04     s1-8:04    b1-8:04
@@ -733,7 +769,7 @@ def test_setup_segmentby_exception(bin_by, bin_on, ordered_on, snap_by, regex_re
             partial(by_x_rows, by=3, closed=RIGHT),
             "dti",
             None,
-            Grouper(key="dti", freq="2T", label="right"),
+            TimeGrouper(key="dti", freq="2T", label="right"),
             #     s1 s2 s3 s4 b1 s5 s6 b2
             #                  4        7
             array([1, 1, 2, 3, 3, 3, 4, 4]),
@@ -833,7 +869,7 @@ def test_segmentby(
 
 
 def test_segmentby_with_outer_setup():
-    # 'bin_by' and 'snap_by' both as a Grouper, left-closed
+    # 'bin_by' and 'snap_by' both as a TimeGrouper, left-closed
     # 'snap_by' points excluded (left-closed)
     # 'data'
     #  datetime       snaps       bins
@@ -842,8 +878,8 @@ def test_segmentby_with_outer_setup():
     #               s3-8:10    b2
     #      8:10     s4-8:12    b3-8:15
     #      8:13     s5-8:14    b3
-    bin_by = Grouper(key="dti", freq="5T", label="right", closed="left")
-    snap_by = Grouper(key="dti", freq="2T", label="right")
+    bin_by = TimeGrouper(key="dti", freq="5T", label="right", closed="left")
+    snap_by = TimeGrouper(key="dti", freq="2T", label="right")
     bin_by = setup_segmentby(bin_by=bin_by, snap_by=snap_by)
     dti = date_range("2020/01/01 08:04", periods=4, freq="3T")
     data = pDataFrame({"dti": dti, "ordered_on": range(len(dti))})
@@ -902,7 +938,7 @@ def test_segmentby_binby_exceptions():
 def test_segmentby_orderedon_exceptions():
     # Check when 'ordered_on' is not ordered.
     bin_on = "ordered_on"
-    bin_by = Grouper(key=bin_on, freq="2T")
+    bin_by = TimeGrouper(key=bin_on, freq="2T")
     ordered_on = bin_on
     # 'ordered_on' is a DatetimeIndex.
     unordered = DatetimeIndex(["2020/01/01 08:00", "2020/01/01 09:00", "2020/01/01 07:00"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 Created on Wed Dec  1 18:35:00 2021.
 
 @author: yoh
+
 """
 import zipfile
 from os import path as os_path
@@ -32,7 +33,7 @@ def test_files_at_depth(tmp_path):
         [
             (DIR_SEP.join(path.rsplit(DIR_SEP, depth)[1:]), sorted(files))
             for path, files in paths_files
-        ]
+        ],
     )
     paths_ref = [
         (f"london.temperature{DIR_SEP}greenwich.summer", ["dataset.parquet"]),
@@ -57,7 +58,7 @@ def test_files_at_depth(tmp_path):
         [
             (DIR_SEP.join(path.rsplit(DIR_SEP, depth)[1:]), sorted(files))
             for path, files in paths_files
-        ]
+        ],
     )
     paths_ref = [
         (f"paris.temperature{DIR_SEP}bastille.summer{DIR_SEP}forgottendir", ["forgottenfile.parq"]),
@@ -67,7 +68,8 @@ def test_files_at_depth(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "closed,label", [("left", "left"), ("right", "left"), ("right", "right"), ("left", "right")]
+    "closed,label",
+    [("left", "left"), ("right", "left"), ("right", "right"), ("left", "right")],
 )
 def test_tcut(closed, label):
     # Test data
@@ -82,7 +84,12 @@ def test_tcut(closed, label):
     df = DataFrame({"a": range(len(ts)), "ts": ts})
     # Test closed=left/label=left.
     grouper = Grouper(
-        key="ts", freq="2H", sort=False, origin="start_day", closed=closed, label=label
+        key="ts",
+        freq="2H",
+        sort=False,
+        origin="start_day",
+        closed=closed,
+        label=label,
     )
     agg_ref = df.groupby(grouper)["a"].agg("first")
     ddf = df.copy()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3,6 +3,7 @@
 Created on Sat Dec 18 15:00:00 2021.
 
 @author: yoh
+
 """
 from os import path as os_path
 
@@ -90,11 +91,12 @@ def test_init_idx_expansion_vaex(tmp_path):
         {
             "('lev1-col1','lev2-col1')": range(6, 12),
             "('lev1-col2','lev2-col2')": ["ah", "oh", "uh", "ih", "ai", "oi"],
-        }
+        },
     )
     res_midx = to_midx(pdf.columns)
     ref_midx = MultiIndex.from_tuples(
-        [("lev1-col1", "lev2-col1"), ("lev1-col2", "lev2-col2")], names=["l0", "l1"]
+        [("lev1-col1", "lev2-col1"), ("lev1-col2", "lev2-col2")],
+        names=["l0", "l1"],
     )
     assert res_midx.equals(ref_midx)
     vdf = from_pandas(pdf)
@@ -111,11 +113,12 @@ def test_init_idx_expansion_sparse_levels(tmp_path):
         {
             "('lev1-col1','lev2-col1')": range(6, 12),
             "('lev1-col2','lev2-col2')": ["ah", "oh", "uh", "ih", "ai", "oi"],
-        }
+        },
     )
     res_midx = to_midx(pdf.columns, levels=["ah"])
     ref_midx = MultiIndex.from_tuples(
-        [("lev1-col1", "lev2-col1"), ("lev1-col2", "lev2-col2")], names=["ah", "l1"]
+        [("lev1-col1", "lev2-col1"), ("lev1-col2", "lev2-col2")],
+        names=["ah", "l1"],
     )
     assert res_midx.equals(ref_midx)
 
@@ -170,7 +173,7 @@ def test_pandas_coalescing_simple_irgs(tmp_path):
     # (size of new data: 1)
     # One incomplete row group in the middle of otherwise complete row groups.
     # Because there is only 1 irgs (while max is 2), and 2 rows over all irgs
-    # (including data to be written), coalesing is not activated.
+    # (including data to be written), coalescing is not activated.
     # rgs                          [ 0,  ,  ,  , 1, 2,  ,  ,  , 3]
     # idx                          [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     # a                            [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -221,7 +224,11 @@ def test_pandas_coalescing_simple_max_row_group_size(tmp_path):
     pdf1 = pDataFrame({"a": range(12)})
     dn = os_path.join(tmp_path, "test")
     fp_write(
-        dn, pdf1, row_group_offsets=[0, 4, 5, 9, 10, 11], file_scheme="hive", write_index=False
+        dn,
+        pdf1,
+        row_group_offsets=[0, 4, 5, 9, 10, 11],
+        file_scheme="hive",
+        write_index=False,
     )
     pf = ParquetFile(dn)
     len_rgs = [rg.num_rows for rg in pf.row_groups]
@@ -695,7 +702,11 @@ def test_pandas_drop_duplicates_wo_coalescing_irgs(tmp_path):
     pdf = pDataFrame({"a": range(n_val), "b": [0] * n_val})
     dn = os_path.join(tmp_path, "test")
     fp_write(
-        dn, pdf, row_group_offsets=[0, n_val - 2, n_val - 1], file_scheme="hive", write_index=False
+        dn,
+        pdf,
+        row_group_offsets=[0, n_val - 2, n_val - 1],
+        file_scheme="hive",
+        write_index=False,
     )
     pf = ParquetFile(dn)
     len_rgs = [rg.num_rows for rg in pf.row_groups]
@@ -727,7 +738,11 @@ def test_ordered_on_not_existing_pandas_vaex(tmp_path):
     dn = os_path.join(tmp_path, "test")
     # Write a 1st set of data.
     fp_write(
-        dn, pdf, row_group_offsets=[0, n_val - 2, n_val - 1], file_scheme="hive", write_index=False
+        dn,
+        pdf,
+        row_group_offsets=[0, n_val - 2, n_val - 1],
+        file_scheme="hive",
+        write_index=False,
     )
     # Append with oups same set of data, pandas dataframe.
     with pytest.raises(ValueError, match="^column 'ts'"):


### PR DESCRIPTION
Oups metadata are now bytes converted (currently with `cloudpickle`, because it is the lib shipped with `joblib`).
This opens the path for using `cumsegagg` in `chainagg`.